### PR TITLE
add TALM operator and refresh assisted service RHCOS versions

### DIFF
--- a/core/assisted-service/02-agentserviceconfig.yaml
+++ b/core/assisted-service/02-agentserviceconfig.yaml
@@ -49,15 +49,22 @@ spec:
       # yamllint enable rule:line-length
     - openshiftVersion: "4.9"
       cpuArchitecture: x86_64
-      version: "49.84.202110081407-0"
+      version: "49.84.202206171736-0"
       # yamllint disable rule:line-length
-      url: "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.9/4.9.0/rhcos-4.9.0-x86_64-live.x86_64.iso"
-      rootFSUrl: "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.9/4.9.0/rhcos-4.9.0-x86_64-live-rootfs.x86_64.img"
+      url: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.9/4.9.40/rhcos-4.9.40-x86_64-live.x86_64.iso
+      rootfs_url: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.9/4.9.40/rhcos-live-rootfs.x86_64.img
       # yamllint enable rule:line-length
     - openshiftVersion: "4.10"
       cpuArchitecture: x86_64
-      version: "410.84.202201251210-0"
+      version: "410.84.202205191234-0"
       # yamllint disable rule:line-length
-      url: "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.10/4.10.16/rhcos-4.10.16-x86_64-live.x86_64.iso"
-      rootFSUrl: "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.10/4.10.16/rhcos-4.10.16-x86_64-live-rootfs.x86_64.img"
+      url: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.10/4.10.16/rhcos-4.10.16-x86_64-live.x86_64.iso
+      rootfs_url: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.10/4.10.16/rhcos-4.10.16-x86_64-live-rootfs.x86_64.img
+      # yamllint enable rule:line-length
+    - openshiftVersion: "4.11"
+      cpuArchitecture: x86_64
+      version: "411.86.202210072320-0"
+      # yamllint disable rule:line-length
+      url: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.11/4.11.9/rhcos-4.11.9-x86_64-live.x86_64.iso
+      rootfs_url: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.11/4.11.9/rhcos-4.11.9-x86_64-live-rootfs.x86_64.img
       # yamllint enable rule:line-length

--- a/core/topology-aware-lifecycle-manager/kustomization.yaml
+++ b/core/topology-aware-lifecycle-manager/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+bases:
+  - github.com/redhat-cop/gitops-catalog/topology-aware-lifecycle-manager-operator/overlays/stable?ref=main


### PR DESCRIPTION
Adds the Topology Aware Lifecycle Manager Operator to our list of bases.  Useful mainly for SNO management at scale, and is a part of Red Hat's ZTP 4.10 solution.

Also refreshing the assisted service's RHCOS images to stay current here.  These are not the absolute latest, but ones we have tested in the lab for sure. Adding 4.11 also to deploy 4.11 Managed (Workload) clusters from the Hub.