### PR TITLE
fixes for rootFSUrl

### DIFF
--- a/core/assisted-service/02-agentserviceconfig.yaml
+++ b/core/assisted-service/02-agentserviceconfig.yaml
@@ -52,19 +52,19 @@ spec:
       version: "49.84.202206171736-0"
       # yamllint disable rule:line-length
       url: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.9/4.9.40/rhcos-4.9.40-x86_64-live.x86_64.iso
-      rootfs_url: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.9/4.9.40/rhcos-live-rootfs.x86_64.img
+      rootFSUrl: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.9/4.9.40/rhcos-live-rootfs.x86_64.img
       # yamllint enable rule:line-length
     - openshiftVersion: "4.10"
       cpuArchitecture: x86_64
       version: "410.84.202205191234-0"
       # yamllint disable rule:line-length
       url: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.10/4.10.16/rhcos-4.10.16-x86_64-live.x86_64.iso
-      rootfs_url: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.10/4.10.16/rhcos-4.10.16-x86_64-live-rootfs.x86_64.img
+      rootFSUrl: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.10/4.10.16/rhcos-4.10.16-x86_64-live-rootfs.x86_64.img
       # yamllint enable rule:line-length
     - openshiftVersion: "4.11"
       cpuArchitecture: x86_64
       version: "411.86.202210072320-0"
       # yamllint disable rule:line-length
       url: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.11/4.11.9/rhcos-4.11.9-x86_64-live.x86_64.iso
-      rootfs_url: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.11/4.11.9/rhcos-4.11.9-x86_64-live-rootfs.x86_64.img
+      rootFSUrl: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.11/4.11.9/rhcos-4.11.9-x86_64-live-rootfs.x86_64.img
       # yamllint enable rule:line-length


### PR DESCRIPTION
Corrects AgentServiceConfig in Core to use the correct parameter rootFSUrl vs rootfs_url (wrong).