### PR TITLE
seed cu1 and du1-fec1 for blazer cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # vse-carslab-hub
-A repository for deploying Openshift clusters with ACM and Argo CD.  
-All cluster lifecycle is managed by Argo CD, including Argo configuration itself.
+A repository for deploying OpenShift clusters with Red Hat Advanced Cluster Management for Kubernetes and OpenShift GitOps.  
+All cluster lifecycle is managed by Argo CD, including the Argo configuration itself.
 
 ## How to run it
 ```shell
@@ -12,9 +12,9 @@ until oc apply -k https://github.com/redhat-partner-solutions/vse-carslab-hub/bo
 |---|----------------|-----------------|
 | 1. | `bootstrap` | This is where openshift-gitops configurations is stored. These are the items that get the cluster/automation started. <br /><br /> `base` is where are the "common" YAML would live and `overlays` are configurations specific to the cluster. |
 | 2. | `components` | This is where specific components for the GitOps Controller lives (in this case Argo CD).<br /><br />`applicationsets` is where all the ApplicationSets YAMLs live.<br /><br />Other things that can live here are RBAC, Git repo, and other Argo CD specific configurations (each in their repsective directories). |
-| 3. | `core` | This is where YAML for the core functionality of the cluster live. Here is where the Kubernetes administrator will put things that is necissary for the functionality of the cluster.<br /><br />Under `gitops-controller` is where you are using Argo CD to manage itself. The `kustomization.yaml` file uses `bootstrap/overlays/default` in it's `bases` configuration. This `core` directory gets deployed as an applicationset which can be found under `components/applicationsets/core-components-appset.yaml`.<br /><br />To add a new "core functionality" workload, one needs to add a directory with some yaml in the `core` directory. See the `advanced-cluster-management` directory as an example.|
-| 4. | `clusters` | This is where the new clusters configuration is stored. <br /><br /> To add a new workload cluster, one needs to add a directory with some yaml in the `overlays` directory. See the `blazer` directory as an example.|
-| 5. | `add-workers` | This is where the configuration to add day2 workers is stored. <br /><br /> To add a day2 worker node to a cluster add the yamls to `add-workers\du3-ldc1\overlay\cluster-name`. See the `add-workers\du3-ldc1\overlay\volante` for an example.|
+| 3. | `core` | This is where YAML for the core functionality of the cluster live. Here is where the Kubernetes administrator will put things that is necessary for the functionality of the cluster.<br /><br />Under `gitops-controller` is where you are using Argo CD to manage itself. The `kustomization.yaml` file uses `bootstrap/overlays/default` in it's `bases` configuration. This `core` directory gets deployed as an applicationset which can be found under `components/applicationsets/core-components-appset.yaml`.<br /><br />To add a new "core functionality" workload, one needs to add a directory with some yaml in the `core` directory. See the `advanced-cluster-management` directory as an example.|
+| 4. | `clusters` | This is where the new clusters configuration is stored. <br /><br /> To add a new Managed cluster, one needs to add a directory with some yaml in the `overlays` directory. See the `blazer` directory as an example.|
+| 5. | `add-workers` | This is where the configuration to add day2 worker nodes is stored. <br /><br /> To add a day2 worker node to an OpenShift cluster, add the yamls to `add-workers\<node-name>\overlay\<cluster-name>`. See the `add-workers\du3-ldc1\overlay\volante` for an example.|
 
 > **Note**
 > This repository is using sealed secrets for secrets management. <br /> If you would like to use another secrets management solution, please change the SealedSecret manifests accordingly.

--- a/add-workers/cu1/kustomization.yaml
+++ b/add-workers/cu1/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ./overlay/blazer/

--- a/add-workers/cu1/overlay/blazer/kustomization.yaml
+++ b/add-workers/cu1/overlay/blazer/kustomization.yaml
@@ -1,0 +1,41 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: blazer-cars-lab
+
+resources:
+  - ../default/
+
+patches:
+  - target:
+      version: v1
+      kind: Namespace
+    patch: |-
+      - op: replace
+        path: /metadata/labels/name
+        value: 'blazer-cars-lab'
+  - target:
+      kind: Secret
+      name: bmc-day2-worker1
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: 'bmc-cu1-blazer-cars-lab'
+  - target:
+      kind: BareMetalHost
+      name: bmh-day2-worker1
+    path: ./patches/bmh-cu1-blazer-cars-lab.yaml
+  - target:
+      kind: NMStateConfig
+      name: nmstate-day2-worker1
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: 'nmstate-cu1-blazer-cars-lab'
+  - target:
+      kind: NMStateConfig
+    patch: |-
+      - op: replace
+        path: /metadata/labels/cluster-name
+        value: 'blazer-cars-lab'

--- a/add-workers/cu1/overlay/blazer/patches/bmh-cu1-blazer-cars-lab.yaml
+++ b/add-workers/cu1/overlay/blazer/patches/bmh-cu1-blazer-cars-lab.yaml
@@ -1,0 +1,10 @@
+---
+- op: replace
+  path: /spec/bmc/credentialsName
+  value: bmc-cu1-blazer-cars-lab
+- op: replace
+  path: /metadata/labels/infraenvs.agent-install.openshift.io
+  value: infraenv
+- op: replace
+  path: /metadata/name
+  value: cu1-blazer-cars-lab

--- a/add-workers/cu1/overlay/default/kustomization.yaml
+++ b/add-workers/cu1/overlay/default/kustomization.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - github.com/redhat-partner-solutions/vse-ocp-bases/base/1-worker?ref=main
+
+patchesStrategicMerge:
+  - ./patches/nmstate-config.yaml
+
+patches:
+  - target:
+      kind: BareMetalHost
+      name: bmh-day2-worker1
+    path: ./patches/bmh-cu1.yaml

--- a/add-workers/cu1/overlay/default/patches/bmh-cu1.yaml
+++ b/add-workers/cu1/overlay/default/patches/bmh-cu1.yaml
@@ -1,0 +1,14 @@
+---
+- op: replace
+  path: /spec/bootMACAddress
+  value: '40:A6:B7:3A:CF:D0'
+- op: replace
+  path: /spec/bmc/address
+  # yamllint disable-line rule:line-length
+  value: idrac-virtualmedia://172.28.11.34/redfish/v1/Systems/System.Embedded.1
+- op: replace
+  path: /spec/bmc/disableCertificateVerification
+  value: true
+- op: replace
+  path: /metadata/annotations/bmac.agent-install.openshift.io~1hostname
+  value: "cu1"

--- a/add-workers/cu1/overlay/default/patches/nmstate-config.yaml
+++ b/add-workers/cu1/overlay/default/patches/nmstate-config.yaml
@@ -1,0 +1,60 @@
+---
+apiVersion: agent-install.openshift.io/v1beta1
+kind: NMStateConfig
+metadata:
+  name: nmstate-day2-worker1
+  labels:
+    cluster-name: workload-cluster-name
+spec:
+  config:
+    interfaces:
+      - name: bondctlplane
+        type: bond
+        state: up
+        ipv4:
+          enabled: true
+          address:
+            - ip: 10.50.0.151
+              prefix-length: 24
+        ipv6:
+          enabled: true
+          address:
+            - ip: fd00:6:6:2052::151
+              prefix-length: 64
+          autoconf: false
+          dhcp: false
+        link-aggregation:
+          mode: 802.3ad
+          options:
+            lacp_rate: "fast"
+          slaves:
+            - ens1f1
+            - ens7f0
+      - name: ens1f0
+        type: ethernet
+        state: down
+      - name: ens7f1
+        type: ethernet
+        state: down
+    dns-resolver:
+      config:
+        server:
+          - 10.40.0.100
+          - fd00:6:6:11::52
+    routes:
+      config:
+        - destination: 0.0.0.0/0
+          next-hop-address: 10.50.0.1
+          next-hop-interface: bondctlplane
+        - destination: ::/0
+          next-hop-address: fd00:6:6:2052::1
+          next-hop-interface: bondctlplane
+  interfaces:
+    - name: "ens1f0"
+      macAddress: "40:a6:b7:3a:e9:80"
+    - name: "ens1f1"
+      macAddress: "40:a6:b7:3a:e9:81"
+    - name: "ens7f0"
+      macAddress: "40:a6:b7:3a:cf:d0"
+    - name: "ens7f1"
+      macAddress: "40:a6:b7:3a:cf:d1"

--- a/add-workers/du1-fec1/kustomization.yaml
+++ b/add-workers/du1-fec1/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ./overlay/blazer/

--- a/add-workers/du1-fec1/overlay/blazer/kustomization.yaml
+++ b/add-workers/du1-fec1/overlay/blazer/kustomization.yaml
@@ -1,0 +1,41 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: blazer-cars-lab
+
+resources:
+  - ../default/
+
+patches:
+  - target:
+      version: v1
+      kind: Namespace
+    patch: |-
+      - op: replace
+        path: /metadata/labels/name
+        value: 'blazer-cars-lab'
+  - target:
+      kind: Secret
+      name: bmc-day2-worker1
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: 'bmc-du1-fec1-blazer-cars-lab'
+  - target:
+      kind: BareMetalHost
+      name: bmh-day2-worker1
+    path: ./patches/bmh-du1-fec1-blazer-cars-lab.yaml
+  - target:
+      kind: NMStateConfig
+      name: nmstate-day2-worker1
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: 'nmstate-du1-fec1-blazer-cars-lab'
+  - target:
+      kind: NMStateConfig
+    patch: |-
+      - op: replace
+        path: /metadata/labels/cluster-name
+        value: 'blazer-cars-lab'

--- a/add-workers/du1-fec1/overlay/blazer/patches/bmh-du1-fec1-blazer-cars-lab.yaml
+++ b/add-workers/du1-fec1/overlay/blazer/patches/bmh-du1-fec1-blazer-cars-lab.yaml
@@ -1,0 +1,10 @@
+---
+- op: replace
+  path: /spec/bmc/credentialsName
+  value: bmc-du1-fec1-blazer-cars-lab
+- op: replace
+  path: /metadata/labels/infraenvs.agent-install.openshift.io
+  value: infraenv
+- op: replace
+  path: /metadata/name
+  value: du1-fec1-blazer-cars-lab

--- a/add-workers/du1-fec1/overlay/default/kustomization.yaml
+++ b/add-workers/du1-fec1/overlay/default/kustomization.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - github.com/redhat-partner-solutions/vse-ocp-bases/base/1-worker?ref=main
+
+patchesStrategicMerge:
+  - ./patches/nmstate-config.yaml
+
+patches:
+  - target:
+      kind: BareMetalHost
+      name: bmh-day2-worker1
+    path: ./patches/bmh-du1-fec1.yaml
+  - target:
+      kind: Provisioning
+      name: provisioning-configuration
+    patch: |-
+      - op: replace
+        path: '/spec/disableVirtualMediaTLS'
+        value: true

--- a/add-workers/du1-fec1/overlay/default/patches/bmh-du1-fec1.yaml
+++ b/add-workers/du1-fec1/overlay/default/patches/bmh-du1-fec1.yaml
@@ -1,0 +1,14 @@
+---
+- op: replace
+  path: /spec/bootMACAddress
+  value: 'AC:1F:6B:E1:80:86'
+- op: replace
+  path: /spec/bmc/address
+  # yamllint disable-line rule:line-length
+  value: redfish-virtualmedia://172.28.11.39/redfish/v1/Systems/1/
+- op: replace
+  path: /spec/bmc/disableCertificateVerification
+  value: true
+- op: replace
+  path: /metadata/annotations/bmac.agent-install.openshift.io~1hostname
+  value: "du1-fec1"

--- a/add-workers/du1-fec1/overlay/default/patches/nmstate-config.yaml
+++ b/add-workers/du1-fec1/overlay/default/patches/nmstate-config.yaml
@@ -1,0 +1,66 @@
+---
+apiVersion: agent-install.openshift.io/v1beta1
+kind: NMStateConfig
+metadata:
+  name: nmstate-day2-worker1
+  labels:
+    cluster-name: workload-cluster-name
+spec:
+  config:
+    interfaces:
+      - name: eno1
+        type: ethernet
+        state: down
+      - name: eno2
+        type: ethernet
+        state: down
+      - name: ens2f0
+        type: ethernet
+        state: up
+        ipv4:
+          address:
+            - ip: 172.18.0.151
+              prefix-length: 24
+          enabled: true
+        ipv6:
+          enabled: true
+          address:
+            - ip: fd00:6:6:2061::151
+              prefix-length: 64
+          autoconf: false
+          dhcp: false
+      - name: ens2f1
+        type: ethernet
+        state: down
+      - name: ens1f0
+        type: ethernet
+        state: down
+      - name: ens1f1
+        type: ethernet
+        state: down
+    dns-resolver:
+      config:
+        server:
+          - 10.40.0.100
+          - fd00:6:6:11::52
+    routes:
+      config:
+        - destination: 0.0.0.0/0
+          next-hop-address: 172.18.0.1
+          next-hop-interface: ens2f0
+        - destination: ::/0
+          next-hop-address: fd00:6:6:2061::1
+          next-hop-interface: ens2f0
+  interfaces:
+    - name: eno1
+      macAddress: "3c:ec:ef:1d:a0:ee"
+    - name: eno2
+      macAddress: "3c:ec:ef:1d:a0:ef"
+    - name: ens1f0
+      macAddress: "50:7c:6f:01:65:80"
+    - name: ens1f1
+      macAddress: "50:7c:6f:01:65:81"
+    - name: ens2f0
+      macAddress: "ac:1f:6b:e1:80:86"
+    - name: ens2f1
+      macAddress: "ac:1f:6b:e1:80:87"


### PR DESCRIPTION
PR adds two nodes for testing in the OpenShift cluster identified as "blazer".  Also some slight semantical updates to the README for the add-workers feature / structure previously defined by @jnunyez .