### PR TITLE
Fix worker nodes appset repo URL typo

### DIFF
--- a/components/applicationsets/worker-nodes-appset.yaml
+++ b/components/applicationsets/worker-nodes-appset.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   generators:
     - git:
-        repoURL: https://github.com/redhat-partners-solutions/vse-carslab-hub
+        repoURL: https://github.com/redhat-partner-solutions/vse-carslab-hub
         revision: main
         directories:
           - path: add-workers/*


### PR DESCRIPTION
Fixing `partner` instead of `partners`