### PR TITLE
Add disableVirtualMediaTLS in global provisioning manifest

### DIFF
--- a/core/assisted-service/01-provisioningoverride.yaml
+++ b/core/assisted-service/01-provisioningoverride.yaml
@@ -9,3 +9,11 @@ metadata:
 spec:
   watchAllNamespaces: true
   provisioningNetwork: Disabled
+  ### Since Provisioning is a global config, we add it under the hub cluster
+  ### configuration.
+  ### Some baremetal systems need HTTP access instead of HTTPS.
+  ### For allowing it, we meed to set disableVirtualMediaTLS true.
+  ### By default, disableVirtualMediaTLS is set to false (using HTTPS).
+  ###
+  ### Remove comments and track the changes in Argo CD
+  # disableVirtualMediaTLS: true


### PR DESCRIPTION
Since `Provisioning` is a global configuration, there is no need to add it to every cluster manifest.