### PR TITLE
Fix bonded interface configuration for CU1

### DIFF
--- a/add-workers/cu1/overlay/default/patches/nmstate-config.yaml
+++ b/add-workers/cu1/overlay/default/patches/nmstate-config.yaml
@@ -10,6 +10,7 @@ spec:
     interfaces:
       - name: bondctlplane
         type: bond
+        mac-address: "40:a6:b7:3a:cf:d0"
         state: up
         ipv4:
           enabled: true


### PR DESCRIPTION
Fixes bonded interface configuration to use a specific mac address for this node, which in this case is two different physical interfaces.