### PR TITLE
Demo1 cluster and worker updates

### DIFF
--- a/add-workers/du3-ldc1/overlay/default/kustomization.yaml
+++ b/add-workers/du3-ldc1/overlay/default/kustomization.yaml
@@ -13,10 +13,3 @@ patches:
       kind: BareMetalHost
       name: bmh-day2-worker1
     path: ./patches/bmh-du3-ldc1.yaml
-  - target:
-      kind: Provisioning
-      name: provisioning-configuration
-    patch: |-
-      - op: replace
-        path: '/spec/disableVirtualMediaTLS'
-        value: true

--- a/add-workers/du4-ldc1/overlay/default/kustomization.yaml
+++ b/add-workers/du4-ldc1/overlay/default/kustomization.yaml
@@ -13,10 +13,3 @@ patches:
       kind: BareMetalHost
       name: bmh-day2-worker1
     path: ./patches/bmh-du4-ldc1.yaml
-  - target:
-      kind: Provisioning
-      name: provisioning-configuration
-    patch: |-
-      - op: replace
-        path: '/spec/disableVirtualMediaTLS'
-        value: true

--- a/clusters/overlays/volante/patches/aci.yaml
+++ b/clusters/overlays/volante/patches/aci.yaml
@@ -10,6 +10,7 @@ spec:
   clusterDeploymentRef:
     name: volante-cars-lab
   imageSetRef:
+    # determine ocp version to install
     name: img4.10.18-x86-64-appsub
   networking:
     clusterNetwork:


### PR DESCRIPTION
- Take out from BMH Provisioning Object from workers since this is configured at the cluster-level (only 1 object).
- Clarify purpose of patching ACI to provision different OCP version(and so different kernel).
- This was done for sriov demo1 and kept in ptp demo2.