### PR TITLE
update RHCOS AgentServiceConfig Images and CRs for Jan 2023

### DIFF
--- a/core/assisted-service/02-agentserviceconfig.yaml
+++ b/core/assisted-service/02-agentserviceconfig.yaml
@@ -44,22 +44,22 @@ spec:
       cpuArchitecture: x86_64
       version: "48.84.202107202156-0"
       # yamllint disable rule:line-length
-      url: "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.8/4.8.14/rhcos-4.8.14-x86_64-live.x86_64.iso"
-      rootFSUrl: "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.8/4.8.14/rhcos-4.8.14-x86_64-live-rootfs.x86_64.img"
+      url: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.8/4.8.14/rhcos-4.8.14-x86_64-live.x86_64.iso
+      rootFSUrl: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.8/4.8.14/rhcos-4.8.14-x86_64-live-rootfs.x86_64.img
       # yamllint enable rule:line-length
     - openshiftVersion: "4.9"
       cpuArchitecture: x86_64
-      version: "49.84.202206171736-0"
+      version: "49.84.202208012046-0"
       # yamllint disable rule:line-length
-      url: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.9/4.9.40/rhcos-4.9.40-x86_64-live.x86_64.iso
-      rootFSUrl: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.9/4.9.40/rhcos-live-rootfs.x86_64.img
+      url: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.9/4.9.45/rhcos-4.9.45-x86_64-live.x86_64.iso
+      rootFSUrl: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.9/4.9.45/rhcos-4.9.45-x86_64-live-rootfs.x86_64.img
       # yamllint enable rule:line-length
     - openshiftVersion: "4.10"
       cpuArchitecture: x86_64
-      version: "410.84.202205191234-0"
+      version: "410.84.202210061459-0"
       # yamllint disable rule:line-length
-      url: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.10/4.10.16/rhcos-4.10.16-x86_64-live.x86_64.iso
-      rootFSUrl: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.10/4.10.16/rhcos-4.10.16-x86_64-live-rootfs.x86_64.img
+      url: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.10/4.10.37/rhcos-4.10.37-x86_64-live.x86_64.iso
+      rootFSUrl: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.10/4.10.37/rhcos-4.10.37-x86_64-live-rootfs.x86_64.img
       # yamllint enable rule:line-length
     - openshiftVersion: "4.11"
       cpuArchitecture: x86_64
@@ -67,4 +67,11 @@ spec:
       # yamllint disable rule:line-length
       url: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.11/4.11.9/rhcos-4.11.9-x86_64-live.x86_64.iso
       rootFSUrl: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.11/4.11.9/rhcos-4.11.9-x86_64-live-rootfs.x86_64.img
+      # yamllint enable rule:line-length
+    - openshiftVersion: "4.12"
+      cpuArchitecture: x86_64
+      version: "412.86.202301061548-0"
+      # yamllint disable rule:line-length
+      url: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.12/4.12.0/rhcos-4.12.0-x86_64-live.x86_64.iso
+      rootFSUrl: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.12/4.12.0/rhcos-4.12.0-x86_64-live-rootfs.x86_64.img
       # yamllint enable rule:line-length

--- a/core/assisted-service/03-clusterimageset.yaml
+++ b/core/assisted-service/03-clusterimageset.yaml
@@ -2,29 +2,29 @@
 apiVersion: hive.openshift.io/v1
 kind: ClusterImageSet
 metadata:
-  name: openshift-v4.8.35
+  name: openshift-v4.8.43
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: "3"
 spec:
-  releaseImage: quay.io/openshift-release-dev/ocp-release:4.8.35-x86_64
+  releaseImage: quay.io/openshift-release-dev/ocp-release:4.8.43-x86_64
 ---
 apiVersion: hive.openshift.io/v1
 kind: ClusterImageSet
 metadata:
-  name: openshift-v4.9.22
+  name: openshift-v4.9.45
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: "3"
 spec:
-  releaseImage: quay.io/openshift-release-dev/ocp-release:4.9.22-x86_64
+  releaseImage: quay.io/openshift-release-dev/ocp-release:4.9.45-x86_64
 ---
 apiVersion: hive.openshift.io/v1
 kind: ClusterImageSet
 metadata:
-  name: openshift-v4.10.16
+  name: openshift-v4.10.37
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: "3"
 spec:
-  releaseImage: quay.io/openshift-release-dev/ocp-release:4.10.16-x86_64
+  releaseImage: quay.io/openshift-release-dev/ocp-release:4.10.37-x86_64

--- a/prerequisites/odf/README.md
+++ b/prerequisites/odf/README.md
@@ -1,2 +1,2 @@
 # OpenShift Data Foundation
-The Assisted Service pod requires at least 2 PersistentVolumes, this is an example for installing OpenShift Data Foundation (ODF).
+The Assisted Service pod requires at least 2 PersistentVolumes, this is an example for installing [Red Hat OpenShift Data Foundation](https://www.redhat.com/en/resources/openshift-data-foundation-datasheet).


### PR DESCRIPTION
This PR:

(1) refreshes RHCOS base images used for the 4.9 & 4.10 releases to a more recent version hosted on the OpenShift mirror site (mirror.openshift.com). These represent four months of RHEL fixes and should be used as a base vs their older counterparts during the provisioning process.
(2) refreshes OpenShift ClusterImageSet to align with respective RHCOS images. Customers and partners should also try to stay current with enhancements and security fixes present in these newer versions.
(3) adds support for OpenShift version 4.12.