### PR TITLE
Change Openshift Pipelines channel to latest

### DIFF
--- a/core/openshift-pipelines/kustomization.yaml
+++ b/core/openshift-pipelines/kustomization.yaml
@@ -4,4 +4,4 @@ kind: Kustomization
 
 
 resources:
-  - github.com/redhat-cop/gitops-catalog/openshift-pipelines-operator/overlays/stable?ref=main
+  - github.com/redhat-cop/gitops-catalog/openshift-pipelines-operator/overlays/latest?ref=main


### PR DESCRIPTION
Change Openshift Pipelines channel to latest as stable is deprecated 
Fix #29