### PR TITLE
Disable clusters appset

### DIFF
--- a/components/applicationsets/kustomization.yaml
+++ b/components/applicationsets/kustomization.yaml
@@ -4,5 +4,5 @@ kind: Kustomization
 
 resources:
   - core-components-appset.yaml
-  - clusters-appset.yaml
+  # - clusters-appset.yaml
   #- worker-nodes-appset.yaml


### PR DESCRIPTION
Disable the clusters appset so it won't try to create the clusters immediately when applying the hub cluster manifests