### PR TITLE
fixes for storageclass and AI pod

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,21 @@
 # vse-carslab-hub
-A repository for deploying OpenShift clusters with Red Hat Advanced Cluster Management for Kubernetes and OpenShift GitOps.  
+This repository helps configure an existing OpenShift cluster as a *Hub cluster*, whereby it can deploy *Managed* OpenShift clusters with Red Hat Advanced Cluster Management (ACM) for Kubernetes and OpenShift GitOps.  Red Hat ACM is responsible for deploying additional OpenShift clusters, typically referred to as *Managed* or *spoke* clusters.
 All cluster lifecycle is managed by Argo CD, including the Argo configuration itself.
+
+## Prerequisites
+In order to successfully use the contents of this repository, you need to have an OpenShift cluster deployed *with* storage available and ready to consume.  The methods of deployment of this OpenShift cluster can be:
+- Red Hat ACM
+- [Baremetal Installer Provisioned Infrastructure] (https://docs.openshift.com/container-platform/4.12/installing/installing_bare_metal_ipi/ipi-install-overview.html)
+- [Crucible Ansible Playbooks] (https://github.com/redhat-partner-solutions/crucible)
+- [Agent Based Installer] (https://docs.openshift.com/container-platform/4.12/installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.html)
+
+Storage can be provided however you deem fit.  Cloud environments typically have dynamic storage available after OpenShift cluster installation.  The requirements are (2) PersistentVolumes available for consumption by the assisted-service and postgres containers in the assisted-service pod.  A few options exist that we can recommend:
+- OpenShift Data Foundation (ODF) is an option for providing dynamic storage provisioning for the resulting OpenShift cluster.
+- Local Storage Operator (LSO) is also an option in resource (CPU, memory, etc) constrained environments as an alternative to ODF.
 
 ## How to run it
 ```shell
+export KUBECONFIG=my-hub-cluster-kubeconfig
 until oc apply -k https://github.com/redhat-partner-solutions/vse-carslab-hub/bootstrap/overlays/default; do sleep 3; done
 ```
 

--- a/core/assisted-service/02-agentserviceconfig.yaml
+++ b/core/assisted-service/02-agentserviceconfig.yaml
@@ -24,16 +24,14 @@ metadata:
     argocd.argoproj.io/sync-wave: "2"
 spec:
   databaseStorage:
-    # bug, leave default class for now
-    # storageClassName: lso-blockclass
+    storageClassName: lso-filesystemclass
     accessModes:
       - ReadWriteOnce
     resources:
       requests:
         storage: 20Gi
   filesystemStorage:
-    # bug, leave default class for now
-    # storageClassName: lso-filesystemclass
+    storageClassName: lso-filesystemclass
     accessModes:
       - ReadWriteOnce
     resources:
@@ -70,8 +68,8 @@ spec:
       # yamllint enable rule:line-length
     - openshiftVersion: "4.12"
       cpuArchitecture: x86_64
-      version: "412.86.202301061548-0"
+      version: "412.86.202302091057-0"
       # yamllint disable rule:line-length
-      url: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.12/4.12.0/rhcos-4.12.0-x86_64-live.x86_64.iso
-      rootFSUrl: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.12/4.12.0/rhcos-4.12.0-x86_64-live-rootfs.x86_64.img
+      url: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.12/4.12.3/rhcos-4.12.3-x86_64-live.x86_64.iso
+      rootFSUrl: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.12/4.12.3/rhcos-4.12.3-x86_64-live-rootfs.x86_64.img
       # yamllint enable rule:line-length


### PR DESCRIPTION
This PR:

(1) refreshes RHCOS base images used for the 4.12 release to a more recent version hosted on the OpenShift mirror site (mirror.openshift.com). These represent a month of RHEL fixes and should be used as a base vs their older counterparts during the provisioning process.
(2) adds the storageClassName to the AgentServiceConfig CR to have the assisted service pod come up successfully where we have deployed the Hub cluster via crucible and add these storageclasses & LSO as an additional manifest / cluster configuration during provisioning
(3) highlights storage requirements in the readme so that it is clearer for the reader / administrator using this repo.