### PR TITLE
seed ODF cleanup

### DIFF
--- a/prerequisites/odf/02-odf/cleanup_ODFnodes.sh
+++ b/prerequisites/odf/02-odf/cleanup_ODFnodes.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# use the following to clean up resident metadata on disk devices used for OpenShift Data Foundation Installs
+# new installations will fail if old data is left resident on disk, in an effort to prevent data loss
+# TBD dcain 21-Mar-2023 convert to a Job
+
+set -xv
+DISKS=(sdb sdc)
+
+oc project default
+# wipe rook directory
+for i in $(oc get node -l cluster.ocs.openshift.io/openshift-storage= -o jsonpath='{ .items[*].metadata.name }'); do oc debug node/${i} -- chroot /host rm -rf /var/lib/rook; done
+
+#wipe partition tables
+for i in $(oc get node -l cluster.ocs.openshift.io/openshift-storage= -o jsonpath='{ .items[*].metadata.name }');
+do
+    for disk in ${DISKS[@]}
+    do
+        oc debug node/${i} -- chroot /host sgdisk --zap-all /dev/$disk
+        oc debug node/${i} -- dd if=/dev/zero of=/dev/$disk bs=1M count=100 oflag=direct,dsync
+    done
+done
+
+oc delete localvolume -n local-storage local-disks --wait=true --timeout=5m
+for i in $(oc get node -l cluster.ocs.openshift.io/openshift-storage= -o jsonpath='{ .items[*].metadata.name }'); do oc debug node/${i} -- chroot /host rm -rf /mnt/local-storage/localblock; done


### PR DESCRIPTION
This PR:

(1) adds a capability to clean metadata from block devices installed in target OpenShift nodes to help clean metadata information from the disks, should they have been used in a previous OpenShift Data Foundation (Ceph) installation.
(2) It is expected that the user references their appropriate kubeconfig to be able to launch debug containers, before running this capability.

Ideally this should be a Kubernetes Job, to be launched before installation of ODF.  An RFE for the future.