### PR TITLE
Use default storageclass in AgentServiceConfig

### DIFF
--- a/core/assisted-service/01-storageclass.yaml
+++ b/core/assisted-service/01-storageclass.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "1"
+  labels:
+    local.storage.openshift.io/owner-name: local-disks
+    local.storage.openshift.io/owner-namespace: openshift-local-storage
+  name: lso-filesystemclass
+provisioner: kubernetes.io/no-provisioner
+reclaimPolicy: Delete
+volumeBindingMode: Immediate

--- a/core/assisted-service/02-agentserviceconfig.yaml
+++ b/core/assisted-service/02-agentserviceconfig.yaml
@@ -24,14 +24,14 @@ metadata:
     argocd.argoproj.io/sync-wave: "2"
 spec:
   databaseStorage:
-    storageClassName: lso-filesystemclass
+    # storageClassName: lso-filesystemclass
     accessModes:
       - ReadWriteOnce
     resources:
       requests:
         storage: 20Gi
   filesystemStorage:
-    storageClassName: lso-filesystemclass
+    # storageClassName: lso-filesystemclass
     accessModes:
       - ReadWriteOnce
     resources:

--- a/core/assisted-service/kustomization.yaml
+++ b/core/assisted-service/kustomization.yaml
@@ -7,3 +7,6 @@ resources:
   - 01-provisioningoverride.yaml
   - 02-agentserviceconfig.yaml
   - 03-clusterimageset.yaml
+  # Remove comment if you are using LSO.
+  # This manifest sets default storageclass
+  # - 01-storageclass.yaml


### PR DESCRIPTION
Use default storageclass in AgentServiceConfig.
Also, adding an option to set default storageclass when using local storage operator