### PR TITLE
add ipv6 for skidoo

### DIFF
--- a/clusters/ztp-siteconfig/skidoo/skidoo-siteconfig.yaml
+++ b/clusters/ztp-siteconfig/skidoo/skidoo-siteconfig.yaml
@@ -8,9 +8,9 @@ spec:
   baseDomain: "cars.lab"
   pullSecretRef:
     name: "assisted-deployment-pull-secret"
-  clusterImageSetNameRef: "img4.9.37-x86-64-appsub"
+  clusterImageSetNameRef: "img4.12.10-x86-64-appsub"
 # yamllint disable-line rule:line-length
-  sshPublicKey: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAID34lV7EwBk4GDNpnGec0mQdXV3VDLwLiBnvbaikdgLE crucible@oc-client.infra.cars.lab"
+  sshPublicKey: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDd7Jj5iFCWv9IHJK9H+2O3lyPs36moAxeAUiHvzRS3uzqGxxB33BnTRBNDKsoDFSGJX0J4bd5b+XyCPdhFOfvn/xhmAcm6d8GALS+139e8d+No8h2QgZy0OVJFp844k4nmz4wew5/+X9DN40ZURYerekbVc58hw1+rTu0uM2jQ0cE2QmEf3qGKHx9UJW8t6IsMzwnrikBH30sYqn2NcBE+/c8JzlLc3PvvenlY0iQkpukI1A5E9GGMR9OS/q+w6FH85zvSgUatOV7Q5lg45QUF+V77DrfX5+niI+NK1g70pRvD8481SAdXrHPB5vK4vQEmJ4pz83IKYHVuPzRnjzYKv1jV33oReyyMqyk44Rsfkxl4i5SJ9z7q/EVmTjvurzD6ofi3Dg0+PL18eTcjuPFdCxSCUFsnr5N9CRHCxHRQpxoZTD7sYD4jDGNygawLvhxcvgKGBZzP53NRCzRFOMFmZsLPLQRaNOsgKRPAohmrn5l8+1xG5ltVauOwAFlKUxk="
   clusters:
     - clusterName: "skidoo"
       clusterLabels:
@@ -19,14 +19,19 @@ spec:
         sites: "r740xls"
       networkType: "OVNKubernetes"
       clusterNetwork:
-        - cidr: "10.128.0.0/14"
+        - cidr: 10.128.0.0/14
           hostPrefix: 23
+        - cidr: fd01::/48
+          hostPrefix: 64
       serviceNetwork:
-        - "172.30.0.0/16"
+        - 172.30.0.0/16
+        - fd02::/112
       machineNetwork:
-        - cidr: "10.60.0.0/24"
+        - cidr: 10.60.0.0/24
+        - cidr: fd00:6:6:2051::0/64
       additionalNTPSources:
-        - 10.40.0.100
+        - registry.cars.lab
+        - fd00:6:6:11::52
       nodes:
         - hostName: "super1.skidoo.cars.lab"
           role: master
@@ -38,6 +43,9 @@ spec:
           bootMode: "UEFI"
           cpuset: "0-3,48-51"
           nodeNetwork:
+            interfaces:
+              - name: "enp1s0"
+                macAddress: "40:A6:B7:3D:B3:70"
             config:
               interfaces:
                 - name: enp1s0
@@ -49,19 +57,24 @@ spec:
                       - ip: 10.60.0.60
                         prefix-length: 24
                   ipv6:
-                    enabled: false
+                    enabled: true
+                    address:
+                      - ip: fd00:6:6:2051::60
+                        prefix-length: 64
+                    autoconf: false
+                    dhcp: false
               dns-resolver:
                 config:
                   search:
                     - cars.lab
                   server:
                     - 10.40.0.100
+                    - fd00:6:6:11::52
               routes:
                 config:
                   - destination: 0.0.0.0/0
-                    next-hop-interface: enp1s0
                     next-hop-address: 10.60.0.1
-                    table-id: 254
-            interfaces:
-              - name: "enp1s0"
-                macAddress: "40:A6:B7:3D:B3:70"
+                    next-hop-interface: enp1s0
+                  - destination: ::/0
+                    next-hop-address: fd00:6:6:2051::1
+                    next-hop-interface: enp1s0


### PR DESCRIPTION
This PR:

1. Adds IPv6 support for the Skidoo Single Node OpenShift cluster.  We should always test with IPv6
2. Streamlines semantics of siteconfig a bit, removes quotes where not necessary
3. Adds VSE ssh key