### PR TITLE
Seed Puffin cluster and add 4.13 and 4.14 images

### DIFF
--- a/clusters/ztp-policies/common/common-policies/common-ranGen-vsesync.yaml
+++ b/clusters/ztp-policies/common/common-policies/common-ranGen-vsesync.yaml
@@ -1,0 +1,84 @@
+---
+apiVersion: ran.openshift.io/v1
+kind: PolicyGenTemplate
+metadata:
+  name: "common-du-vsesync"
+  namespace: "ztp-common"
+spec:
+  bindingRules:
+    # These policies will correspond to all clusters with this label:
+    common-du-vsesync: "true"
+  sourceFiles:
+    # Create operators policies that will be installed in all clusters
+    - fileName: SriovSubscription.yaml
+      policyName: "subscriptions-policy"
+    - fileName: SriovSubscriptionNS.yaml
+      policyName: "subscriptions-policy"
+    - fileName: SriovSubscriptionOperGroup.yaml
+      policyName: "subscriptions-policy"
+    - fileName: SriovOperatorStatus.yaml
+      policyName: "subscriptions-policy"
+#    - fileName: PtpSubscription.yaml
+#      policyName: "subscriptions-policy"
+#    - fileName: PtpSubscriptionNS.yaml
+#      policyName: "subscriptions-policy"
+#    - fileName: PtpSubscriptionOperGroup.yaml
+#      policyName: "subscriptions-policy"
+#    - fileName: PtpOperatorStatus.yaml
+#      policyName: "subscriptions-policy"
+    - fileName: ClusterLogNS.yaml
+      policyName: "subscriptions-policy"
+    - fileName: ClusterLogOperGroup.yaml
+      policyName: "subscriptions-policy"
+    - fileName: ClusterLogSubscription.yaml
+      policyName: "subscriptions-policy"
+    - fileName: ClusterLogOperatorStatus.yaml
+      policyName: "subscriptions-policy"
+    - fileName: StorageNS.yaml
+      policyName: "subscriptions-policy"
+    - fileName: StorageOperGroup.yaml
+      policyName: "subscriptions-policy"
+    - fileName: StorageSubscription.yaml
+      policyName: "subscriptions-policy"
+    - fileName: StorageOperatorStatus.yaml
+      policyName: "subscriptions-policy"
+    # - fileName: AmqSubscriptionNS.yaml
+    #   policyName: "subscriptions-policy"
+    # - fileName: AmqSubscriptionOperGroup.yaml
+    #   policyName: "subscriptions-policy"
+    # - fileName: AmqSubscription.yaml
+    #   policyName: "subscriptions-policy"
+    # - fileName: BareMetalEventRelaySubscriptionNS.yaml
+    #   policyName: "subscriptions-policy"
+    # - fileName: BareMetalEventRelaySubscriptionOperGroup.yaml
+    #   policyName: "subscriptions-policy"
+    # - fileName: BareMetalEventRelaySubscription.yaml
+    #   policyName: "subscriptions-policy"
+    - fileName: ReduceMonitoringFootprint.yaml
+      policyName: "config-policy"
+    #
+    # These CRs are in support of installation from a disconnected registry
+    #
+# dcain 27-June enable someday
+
+#    - fileName: OperatorHub.yaml
+#      policyName: "config-policy"
+#    - fileName: DefaultCatsrc.yaml
+#      policyName: "config-policy"
+      # The Subscriptions all point to redhat-operators. The OperatorHub CR
+      # disables the defaults and this CR replaces redhat-operators with a
+      # CatalogSource pointing to the disconnected registry. Including both of
+      # these in the same policy orders their application to the cluster.
+#      metadata:
+#        name: redhat-operators
+#      spec:
+#        displayName: disconnected-redhat-operators
+# yamllint disable-line rule:line-length
+#        image: registry.example.com:5000/disconnected-redhat-operators/disconnected-redhat-operator-index:v4.9
+#    - fileName: DisconnectedICSP.yaml
+#      policyName: "config-policy"
+#      spec:
+#        repositoryDigestMirrors:
+#        - mirrors:
+#          - registry.example.com:5000
+#          source: registry.redhat.io

--- a/clusters/ztp-policies/common/group-policies/group-dellr740-vse1-validator.yaml
+++ b/clusters/ztp-policies/common/group-policies/group-dellr740-vse1-validator.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: ran.openshift.io/v1
+kind: PolicyGenTemplate
+metadata:
+  # yamllint disable-line rule:line-length
+  # The name will be used to generate the placementBinding name as {name}-placementBinding, the placementRule name as {name}-placementRule,
+  # and the policy name as {name}-{spec.sourceFiles[x].policyName}
+  name: "group-dellr740-vse1-validator"
+  namespace: "ztp-group"
+spec:
+  bindingRules:
+    # yamllint disable-line rule:line-length
+    # This policy will correspond to all clusters with label specified in bindingRules and
+    # without label specified in bindingExcludedRules.
+    group-dellr740-vse1: ""
+  bindingExcludedRules:
+    # yamllint disable-line rule:line-length
+    # The ztp-done label is used in coordination with the Topology Aware Lifecycle Operator(TALO).
+    # Please do not change this label.
+    ztp-done: ""
+  mcp: "master"
+  sourceFiles:
+    # yamllint disable-line rule:line-length
+    # Create inform policy to validate configuration CRs that will be applied to all SNO clusters
+    - fileName: validatorCRs/informDuValidator.yaml
+      remediationAction: inform
+      policyName: "du-policy"

--- a/clusters/ztp-policies/common/group-policies/group-dellr740-vse1.yaml
+++ b/clusters/ztp-policies/common/group-policies/group-dellr740-vse1.yaml
@@ -1,0 +1,197 @@
+---
+# yamllint disable
+apiVersion: ran.openshift.io/v1
+kind: PolicyGenTemplate
+metadata:
+  # The name will be used to generate the placementBinding and placementRule names as {name}-placementBinding and {name}-placementRule
+  name: "group-dellr740-vse1"
+  namespace: "ztp-group"
+spec:
+  bindingRules:
+    # These policies will correspond to all clusters with this label:
+    group-dellr740-vse1: ""
+  mcp: "master"
+  sourceFiles:
+    - fileName: ClusterLogging.yaml
+      policyName: "config-policy"
+      spec:
+        collection:
+          type: vector
+    # The setting below overrides the default "worker" selector predefined in
+    # the source-crs. The change is recommended on SNOs configured with PTP 
+    # event notification for forward compatibility with possible SNO expansion.
+    # When the default setting is left intact, then in case of an SNO 
+    # expansion with one or more workers, PTP operator
+    # would not create linuxptp-daemon containers on the worker node(s). Any
+    # attempt to change the daemonsetNodeSelector will result in ptp daemon
+    # restart and time synchronization loss.
+    # After complying with the policy, complianceType can be set to a safer "musthave"
+    # - fileName: PtpOperatorConfigForEvent.yaml
+    #   policyName: "config-policy"
+    #   complianceType: mustonlyhave
+    #   spec:
+    #     daemonNodeSelector:
+    #       node-role.kubernetes.io/worker: ""
+    #     ptpEventConfig:
+    #       storageType: "storage-class-http-events"
+
+#    - fileName: PtpConfigSlave.yaml   # Change to PtpConfigSlaveCvl.yaml for ColumbiaVille NIC
+#      policyName: "config-policy"
+#      metadata:
+#        name: "du-ptp-slave"
+#      spec:
+#        profile:
+#        - name: "slave"
+          # This interface must match the hardware in this group
+#          interface: "ens5f0"
+#          ptp4lOpts: "-2 -s --summary_interval -4"
+#          phc2sysOpts: "-a -r -n 24"
+    - fileName: SriovOperatorConfig.yaml
+      policyName: "config-policy"
+      # For existing clusters with node selector set as "master", 
+      # change the complianceType to "mustonlyhave".
+      # After complying with the policy, the complianceType can 
+      # be reverted to "musthave"
+      complianceType: musthave
+      spec:
+        configDaemonNodeSelector:
+          node-role.kubernetes.io/worker: ""
+#    - fileName: StorageLV.yaml
+#      policyName: "config-policy"
+#      spec:
+#        storageClassDevices:
+#        - storageClassName: "example-storage-class-1"
+#          volumeMode: Filesystem
+#          fsType: xfs
+#          devicePaths:
+#          - /dev/sdb1
+#        - storageClassName: "example-storage-class-2"
+#          volumeMode: Filesystem
+#          fsType: xfs
+#          devicePaths:
+#          - /dev/sdb2
+        # This is required if PTP and BMER operators use HTTP transport.
+        # The disk labels are created by ignitionConfigOverride in siteConfig.
+        # - storageClassName: "storage-class-http-events"
+        #   volumeMode: Filesystem
+        #   fsType: xfs
+        #   devicePaths:
+        #   - /dev/disk/by-partlabel/httpevent1
+        #   - /dev/disk/by-partlabel/httpevent2
+    - fileName: DisableSnoNetworkDiag.yaml
+      policyName: "config-policy"
+    - fileName: PerformanceProfile.yaml
+      policyName: "config-policy"
+      spec:
+        cpu:
+          # These must be tailored for the specific hardware platform
+          isolated: "2-19,22-39"
+          reserved: "0-1,20-21"
+        hugepages:
+          defaultHugepagesSize: 1G
+          pages:
+            - size: 1G
+              count: 16
+        workloadHints:
+          realTime: true
+          highPowerConsumption: false
+          perPodPowerManagement: false
+    - fileName: TunedPerformancePatch.yaml
+      policyName: "config-policy"
+      spec:
+        profile:
+          - name: performance-patch
+            data: |
+              [main]
+              summary=Configuration changes profile inherited from performance created tuned
+              include=openshift-node-performance-openshift-node-performance-profile
+              [sysctl]
+              kernel.timer_migration=1
+              [scheduler]
+              group.ice-ptp=0:f:10:*:ice-ptp.*
+              group.ice-gnss=0:f:10:*:ice-gnss.*
+              [service]
+              service.stalld=start,enable
+              service.chronyd=stop,disable
+    # # AmqInstance is required if PTP and BMER operators use AMQP transport
+    # - fileName: AmqInstance.yaml
+    #   policyName: "config-events-policy"
+    #   annotations:
+    #     ran.openshift.io/ztp-deploy-wave: "10"
+    # - fileName: HardwareEvent.yaml
+    #   policyName: "config-events-policy"
+    #   spec:
+    #     nodeSelector: {}
+    #     transportHost: "amqp://amq-router.amq-router.svc.cluster.local"
+    #     # transportHost: "http://hw-event-publisher-service.openshift-bare-metal-events.svc.cluster.local:9043"
+    #     # storageType: "storage-class-http-events"
+    #     logLevel: "debug"
+    #
+    # These CRs are to enable crun on master and worker nodes for 4.13+ only
+    #
+    # Include these CRs in the group PGT instead of the common PGT to make sure
+    # they are applied after the operators have been successfully installed,
+    # however, it's strongly recommended to include these CRs as day-0 extra manifests
+    # to avoid the risk of an extra reboot.
+    - fileName: optional-extra-manifest/enable-crun-master.yaml
+      policyName: "config-policy"
+    - fileName: optional-extra-manifest/enable-crun-worker.yaml
+      policyName: "config-policy"
+#    --- sources needed for image registry (check ImageRegistry.md for more details)----
+#    - fileName: StorageClass.yaml
+#      policyName: "config-policy"
+#      metadata:
+#        name: image-registry-sc
+#    - fileName: StoragePVC.yaml
+#      policyName: "config-policy"
+#      metadata:
+#        name: image-registry-pvc
+#        namespace: openshift-image-registry
+#      spec:
+#        accessModes:
+#          - ReadWriteMany
+#        resources:
+#          requests:
+#            storage: 100Gi
+#        storageClassName: image-registry-sc
+#        volumeMode: Filesystem
+#    - fileName: ImageRegistryPV.yaml  # this is assuming that mount_point is set to `/var/imageregistry` in SiteConfig
+                                       # using StorageClass `image-registry-sc` (see the first sc-file)
+#      policyName: "config-policy"
+#    - fileName: ImageRegistryConfig.yaml
+#      policyName: "config-policy"
+#      spec:
+#        storage:
+#          pvc:
+#            claim: "image-registry-pvc"
+#     ---- sources needed for image registry ends here ----
+
+#    --- sources needed for updating CRI-O workload-partitioning ----
+#      more info here: on the base64 content https://docs.openshift.com/container-platform/4.11/scalability_and_performance/sno-du-enabling-workload-partitioning-on-single-node-openshift.html
+#    - fileName: MachineConfigGeneric.yaml
+#      policyName: "config-policy"
+#      complianceType: mustonlyhave # This is to update array entry as opposed to appending a new entry.
+#      metadata:
+#        name: 02-master-workload-partitioning
+#      spec:
+#        config:
+#          storage:
+#            files:
+#              - contents:
+#                  # crio cpuset config goes below. This value needs to updated and matched PerformanceProfile. Check the link for more info on the content.
+#                  source: data:text/plain;charset=utf-8;base64,W2NyaW8ucnVudGltZS53b3JrbG9hZHMubWFuYWdlbWVudF0KYWN0aXZhdGlvbl9hbm5vdGF0aW9uID0gInRhcmdldC53b3JrbG9hZC5vcGVuc2hpZnQuaW8vbWFuYWdlbWVudCIKYW5ub3RhdGlvbl9wcmVmaXggPSAicmVzb3VyY2VzLndvcmtsb2FkLm9wZW5zaGlmdC5pbyIKcmVzb3VyY2VzID0geyAiY3B1c2hhcmVzIiA9IDAsICJjcHVzZXQiID0gIjAtMSwyLTMiIH0=
+#                mode: 420
+#                overwrite: true
+#                path: /etc/crio/crio.conf.d/01-workload-partitioning
+#                user:
+#                  name: root
+#              - contents:
+#                  # openshift cpuset config goes below. This value needs to be updated and matched with crio cpuset (array entry above this). Check the link for more info on the content.
+#                  source: data:text/plain;charset=utf-8;base64,ewogICJtYW5hZ2VtZW50IjogewogICAgImNwdXNldCI6ICIwLTEsNTItNTMiCiAgfQp9Cg==
+#                mode: 420
+#                overwrite: true
+#                path: /etc/kubernetes/openshift-workload-pinning
+#                user:
+#                  name: root
+#     ---- sources needed for updating CRI-O workload-partitioning ends here ----
+# yamllint enable

--- a/clusters/ztp-policies/common/kustomization.yaml
+++ b/clusters/ztp-policies/common/kustomization.yaml
@@ -9,13 +9,26 @@ generators:
  # This is common to all RAN deployments
  - common-policies/common-ranGen.yaml
  # yamllint disable-line rule:line-length
- # This group policy is for all Dell EMC XR12 based deployments:
- - group-policies/group-vdu.yaml
- - group-policies/group-supermicro.yaml
+ # This is common to all RAN DU deployments for vRAN Solution Enablement's Synchronization Workgroup
+ - common-policies/common-ranGen-vsesync.yaml
+
  # yamllint disable-line rule:line-length
- # This group validator policy is for all Dell EMC XR12 based deployments:
- - group-policies/group-vdu-validator.yaml
+ # This group policy is for some Supermicro X11 based deployments:
+ - group-policies/group-supermicro.yaml
  - group-policies/group-supermicro-validator.yaml
+ # yamllint disable-line rule:line-length
+ # This group policy is for all Dell R740 based deployments with SKU VSE-1:
+ - group-policies/group-dellr740-vse1.yaml
+ - group-policies/group-dellr740-vse1-validator.yaml
+ # yamllint disable-line rule:line-length
+ # This group validator policy is for some Supermicro X11 based deployments:
+ - group-policies/group-vdu.yaml
+ - group-policies/group-vdu-validator.yaml
+
+ # yamllint disable-line rule:line-length
+ # These are policies that are unique for a site or OpenShift cluster:
+ - site-specific-policies/puffin-wpc-test.yaml
+
  # This group policy is for all compressed 3-node cluster deployments:
  # - group-du-3node-ranGen.yaml
  # yamllint disable-line rule:line-length

--- a/clusters/ztp-policies/common/site-specific-policies/puffin-wpc-test.yaml
+++ b/clusters/ztp-policies/common/site-specific-policies/puffin-wpc-test.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: ran.openshift.io/v1
+kind: PolicyGenTemplate
+metadata:
+  # yamllint disable-line rule:line-length
+  # The name will be used to generate the placementBinding and placementRule names as {name}-placementBinding and {name}-placementRule
+  name: "puffin-wpc-test"
+  namespace: "ztp-site"
+spec:
+  bindingRules:
+    # These policies will correspond to all clusters with this label:
+    sites: "puffin-wpc-test"
+  mcp: "master"
+  sourceFiles:
+    - fileName: ClusterLogForwarder.yaml
+      policyName: "config-policy"
+      spec:
+        outputs:
+          - name: loki-infra
+            secret:
+              name: remote-logging-secret
+            type: loki
+            # yamllint disable-line rule:line-length
+            url: https://logging-loki-openshift-logging.apps.yukon.cars2.lab/api/logs/v1/infrastructure
+        pipelines:
+          - name: send-infra-logs
+            inputRefs:
+              - infrastructure
+            outputRefs:
+              - loki-infra
+            labels:
+              clustername: puffin

--- a/clusters/ztp-siteconfig/puffin.wpc.test/kustomization.yaml
+++ b/clusters/ztp-siteconfig/puffin.wpc.test/kustomization.yaml
@@ -1,0 +1,46 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+generators:
+ - puffin-siteconfig.yaml
+
+resources:
+ - github.com/redhat-partner-solutions/vse-ocp-bases/base/ztp/site-config?ref=main
+
+patches:
+ - target:
+    kind: Secret
+   patch: |-
+     - op: replace
+       path: /metadata/name
+       value: 'puffin-bmc-creds-secret'
+     - op: replace
+       path: /metadata/namespace
+       value: 'puffin-wpc-test'
+     - op: replace
+       path: /data/username
+       value: 'cm9vdA=='
+     - op: replace
+       path: /data/password
+       value: 'Y2FsdmluCg=='
+ - target:
+    kind: SealedSecret
+   patch: |-
+     - op: replace
+       path: /metadata/name
+       value: 'assisted-deployment-pull-secret'
+     - op: replace
+       path: /metadata/namespace
+       value: 'puffin-wpc-test'
+     - op: replace
+       path: /spec/encryptedData/.dockerconfigjson
+       value: 'xxxxx'
+     - op: replace
+       path: /spec/encryptedData/type
+     - op: replace
+       path: /spec/template/metadata/name
+       value: 'puffin-bmc-creds-secret'
+     - op: replace
+       path: /spec/template/metadata/namespace
+       value: 'puffin-wpc-test'

--- a/clusters/ztp-siteconfig/puffin.wpc.test/puffin-siteconfig.yaml
+++ b/clusters/ztp-siteconfig/puffin.wpc.test/puffin-siteconfig.yaml
@@ -1,0 +1,117 @@
+---
+# yamllint disable rule:line-length
+apiVersion: ran.openshift.io/v1
+kind: SiteConfig
+metadata:
+  name: "puffin-wpc-test"
+  namespace: "puffin-wpc-test"
+spec:
+  baseDomain: "wpc.test"
+  pullSecretRef:
+    name: "assisted-deployment-pull-secret"
+  clusterImageSetNameRef: "img4.13.4-x86-64-appsub"
+  sshPublicKey: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDd7Jj5iFCWv9IHJK9H+2O3lyPs36moAxeAUiHvzRS3uzqGxxB33BnTRBNDKsoDFSGJX0J4bd5b+XyCPdhFOfvn/xhmAcm6d8GALS+139e8d+No8h2QgZy0OVJFp844k4nmz4wew5/+X9DN40ZURYerekbVc58hw1+rTu0uM2jQ0cE2QmEf3qGKHx9UJW8t6IsMzwnrikBH30sYqn2NcBE+/c8JzlLc3PvvenlY0iQkpukI1A5E9GGMR9OS/q+w6FH85zvSgUatOV7Q5lg45QUF+V77DrfX5+niI+NK1g70pRvD8481SAdXrHPB5vK4vQEmJ4pz83IKYHVuPzRnjzYKv1jV33oReyyMqyk44Rsfkxl4i5SJ9z7q/EVmTjvurzD6ofi3Dg0+PL18eTcjuPFdCxSCUFsnr5N9CRHCxHRQpxoZTD7sYD4jDGNygawLvhxcvgKGBZzP53NRCzRFOMFmZsLPLQRaNOsgKRPAohmrn5l8+1xG5ltVauOwAFlKUxk="
+  clusters:
+    - clusterName: "puffin"
+      networkType: "OVNKubernetes"
+      # installConfigOverrides is a generic way of passing install-config
+      # parameters through the siteConfig.  The 'capabilities' field configures
+      # the composable openshift feature.  In this 'capabilities' setting, we
+      # remove all but the marketplace component from the optional set of
+      # components.
+      # Notes:
+      # - NodeTuning is needed for 4.13 and later, not for 4.12 and earlier
+      installConfigOverrides: "{\"capabilities\":{\"baselineCapabilitySet\": \"None\", \"additionalEnabledCapabilities\": [ \"marketplace\", \"NodeTuning\" ] }}"
+      # It is strongly recommended to include crun manifests as part of the additional install-time manifests for 4.13+.
+      # The crun manifests can be obtained from source-crs/optional-extra-manifest/ and added to the git repo ie.sno-extra-manifest.
+      # extraManifestPath: sno-extra-manifest
+      clusterLabels:
+        common-du-vsesync: true
+        group-dellr740-vse1: ""
+        sites: "puffin-wpc-test"
+      clusterNetwork:
+        - cidr: 10.128.0.0/14
+          hostPrefix: 23
+#        - cidr: fd01::/48
+#          hostPrefix: 64
+      serviceNetwork:
+        - 172.30.0.0/16
+#        - fd02::/112
+      machineNetwork:
+        - cidr: 192.168.49.128/25
+#        - cidr: fd00:6:6:2051::0/64
+      additionalNTPSources:
+        - clock.cars2.lab
+#        - clock-v6.cars2.lab
+      #crTemplates:
+      #  KlusterletAddonConfig: "KlusterletAddonConfigOverride.yaml"
+      nodes:
+        - hostName: "r740-u3.puffin.wpc.test"
+          role: master
+          # Optionally; This can be used to configure desired BIOS setting on a host:
+          #biosConfigRef:
+          #  filePath: "example-hw.profile"
+          bmcAddress: "idrac-virtualmedia://192.168.49.251/redfish/v1/Systems/System.Embedded.1"
+          bmcCredentialsName:
+            name: "puffin-bmc-creds-secret"
+          bootMACAddress: "40:a6:b7:2b:2b:31"
+          bootMode: "UEFI"
+          rootDeviceHints:
+            wwn: "0x62cea7f06271f8002720a81f298bfdcc"
+          # example of diskPartition below is used for image registry (check ImageRegistry.md for more details), but it's not limited to this use case
+#          diskPartition:
+#            - device: /dev/disk/by-id/wwn-0x11111000000asd123 # match rootDeviceHints
+#              partitions:
+#                - mount_point: /var/imageregistry
+#                  size: 102500
+#                  start: 344844
+         # allocate partitions for persist storage used by HTTP transport subscription data for PTP and BMER operators.
+         # disk id and and size needs to be adjusted to the hardware
+         # ignitionConfigOverride: '{"ignition":{"version":"3.2.0"},"storage":{"disks":[{"device":"/dev/disk/by-id/wwn-0x11111000000asd123","wipeTable":false,"partitions":[{"sizeMiB":16,"label":"httpevent1","startMiB":350000},{"sizeMiB":16,"label":"httpevent2","startMiB":350016}]}],"filesystem":[{"device":"/dev/disk/by-partlabel/httpevent1","format":"xfs","wipeFilesystem":true},{"device":"/dev/disk/by-partlabel/httpevent2","format":"xfs","wipeFilesystem":true}]}}'
+          cpuset: "0-1,20-21" # match the value with PerformanceProfile's .spec.cpu.reserved for workload partitioning.
+          nodeNetwork:
+            interfaces:
+              - name: ens2f0
+                macAddress: "50:7c:6f:1f:b5:4c"
+              - name: ens2f3
+                macAddress: "50:7c:6f:1f:b5:4f"
+              - name: ens3f1
+                macAddress: "40:a6:b7:2b:2b:31"
+            config:
+              interfaces:
+                - name: ens2f0
+                  type: ethernet
+                  state: down
+                - name: ens2f3
+                  type: ethernet
+                  state: down
+                - name: ens3f1
+                  type: ethernet
+                  state: up
+                  ipv4:
+                    enabled: true
+                    address:
+                      - ip: 192.168.49.151
+                        prefix-length: 25
+                  ipv6:
+                    enabled: false
+#                    address:
+#                      - ip: fd00:6:6:2051::60
+#                        prefix-length: 64
+#                    autoconf: false
+#                    dhcp: false
+              dns-resolver:
+                config:
+                  search:
+                    - wpc.test
+                  server:
+                    - 192.168.38.12
+#                    - 2600:52:7:38::12
+              routes:
+                config:
+                  - destination: 0.0.0.0/0
+                    next-hop-address: 192.168.49.129
+                    next-hop-interface: ens3f1
+#                  - destination: ::/0
+#                    next-hop-address: fd00:6:6:2051::1
+#                    next-hop-interface: ens3f1

--- a/core/advanced-cluster-management/02-agentserviceconfig.yaml
+++ b/core/advanced-cluster-management/02-agentserviceconfig.yaml
@@ -68,8 +68,22 @@ spec:
       # yamllint enable rule:line-length
     - openshiftVersion: "4.12"
       cpuArchitecture: x86_64
-      version: "412.86.202302091057-0"
+      version: "412.86.202305030814-0"
       # yamllint disable rule:line-length
-      url: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.12/4.12.3/rhcos-4.12.3-x86_64-live.x86_64.iso
-      rootFSUrl: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.12/4.12.3/rhcos-4.12.3-x86_64-live-rootfs.x86_64.img
+      url: https://mirror.openshift.com/pub/openshift-v4/amd64/dependencies/rhcos/4.12/4.12.17/rhcos-4.12.17-x86_64-live.x86_64.iso
+      rootFSUrl: https://mirror.openshift.com/pub/openshift-v4/amd64/dependencies/rhcos/4.12/4.12.17/rhcos-4.12.17-x86_64-live-rootfs.x86_64.img
+      # yamllint enable rule:line-length
+    - openshiftVersion: "4.13"
+      cpuArchitecture: x86_64
+      version: "413.92.202305021736-0"
+      # yamllint disable rule:line-length
+      url: https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/4.13/latest/rhcos-4.13.0-x86_64-live.x86_64.iso
+      rootFSUrl: https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/4.13/latest/rhcos-4.13.0-x86_64-live-rootfs.x86_64.img
+      # yamllint enable rule:line-length
+    - openshiftVersion: "4.14"
+      cpuArchitecture: x86_64
+      version: "414.92.202306100411-0"
+      # yamllint disable rule:line-length
+      url: https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/pre-release/latest-4.14/rhcos-4.14.0-ec.2-x86_64-live.x86_64.iso
+      rootFSUrl: https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/pre-release/latest-4.14/rhcos-4.14.0-ec.2-x86_64-live-rootfs.x86_64.img
       # yamllint enable rule:line-length


### PR DESCRIPTION
This PR:

1. Seeds the Puffin cluster as a SiteConfig in the vse-carslab-hub repo.  Puffin is a Dell R740 system in Rack 402 of the Telco Partner Lab.  It is desired to deploy 4.13 using the DU Profile for this cluster.
2. Seeds common-ranGen-vsesync.yaml, which is a common policy for Day-2 Operator installs representative of a DU node, minus the default included (and GA) PTP Operator from Red Hat.  This we will call the vsesync common configuration.
3. Seeds group-dellr740-vse1.yaml, which is a group policy for the Dell R740 in question we are using.  The suffix `vse1` is  added to signify that this is a SKU we should use to group "like" assets of server hardware in our labs.
4.  Seeds new site policy folder and Policy puffin-wpc-test.yaml, which is unique configuration for the OpenShift cluster "Puffin" itself.  In this case, the workaround I have for ClusterLogForwarding via Loki uses the cluster name itself.  SR-IOV configuration can be added here in the future if unique, or if more R740 servers are added for deployment, adding those assets to the Group policies.
5. Corrects some incorrect nomenclature / naming in the kustomization.yaml file in ztp-policies/common.

**Note**: I have ensured these manifests render, but have not had a chance to test myself personally.