### PR TITLE
seed ACM observability 1

### DIFF
--- a/core/advanced-cluster-management-observability/01-cm-userworkload.yaml
+++ b/core/advanced-cluster-management-observability/01-cm-userworkload.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-monitoring-config
+  namespace: openshift-monitoring
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "1"
+data:
+  config.yaml: |
+    enableUserWorkload: true
+  ### This option allows monitoring on user specified projects, such as those
+  ### that are of the containerized or virtualized Network Function variety.
+  ### By default, enableUserWorkload is set to false (no metrics collection).

--- a/core/advanced-cluster-management-observability/02-cm-metrics-custom-allowlist.yaml
+++ b/core/advanced-cluster-management-observability/02-cm-metrics-custom-allowlist.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: observability-metrics-custom-allowlist
+  namespace: open-cluster-management-observability
+data:
+  metrics_list.yaml: |
+    names:
+      - node_hwmon_temp_celsius
+      - node_hwmon_power_average_watt
+    collect_rules:
+      - group: -SNOResourceUsage
+  ### This ConfigMap overrides default behavior of collecting
+  ### custom metrics on SNO. This is useful to collect more metrics
+  ### through node-exporter (Prometheus). By default, many metrics will
+  ### not be collected on SNO.

--- a/core/advanced-cluster-management-observability/kustomization.yaml
+++ b/core/advanced-cluster-management-observability/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - github.com/redhat-cop/gitops-catalog/advanced-cluster-management/instance/observability?ref=main
+  - 01-cm-userworkload.yaml
+  - 02-cm-metrics-custom-allowlist.yaml


### PR DESCRIPTION
This PR:

1. Seeds an initial PR for leveraging the Advanced Cluster Management for Kubernetes (RHACM) Observability-Add on.  This is a product version of Observatorium / Thanos for custom metric storage.  We aim to use this on our Hub cluster environments for storing prometheus metrics, which in our case use ODF as the storage backend using fast SSD or NVMe backed storage media.
2. The GitOps CoP repo (https://github.com/redhat-cop/gitops-catalog) contained much of the collateral needed for this, which I used previously a month ago on OCP 4.12.
3. Grafana integration to visualize those stored metrics is not included in this, but will be scoped and added later.  By default Red Hat prevents modifying the default provided Grafana dashboards included with the Observability add-on.  User created dashboards with custom metrics collected is possible, it just needs some additional configuration.