### PR TITLE
add WPC and FEC configuration for SKU VSE2

### DIFF
--- a/clusters/ztp-policies/common/group-policies/group-smcx12-vse2.yaml
+++ b/clusters/ztp-policies/common/group-policies/group-smcx12-vse2.yaml
@@ -12,6 +12,12 @@ spec:
     group-smcx12-vse2: ""
   mcp: "master"
   sourceFiles:
+    - fileName: AcceleratorsNS.yaml
+      policyName: "subscriptions-policy"
+    - fileName: AcceleratorsOperGroup.yaml
+      policyName: "subscriptions-policy"
+    - fileName: AcceleratorsSubscription.yaml
+      policyName: "subscriptions-policy"
     - fileName: ClusterLogging.yaml
       policyName: "config-policy"
       spec:
@@ -37,7 +43,133 @@ spec:
     #       node-role.kubernetes.io/worker: ""
     #     ptpEventConfig:
     #       storageType: "storage-class-http-events"
-
+    - fileName: PtpConfigGmWpc.yaml
+      policyName: "config-policy"
+      spec:
+        profile:
+        - name: "grandmaster"
+          phc2sysOpts: -r -u 0 -m -O -37 -N 8 -R 16 -s ens6f0 -n 24
+          ptp4lConf: |
+            [ens6f0]
+            masterOnly 1
+            [global]
+            #
+            # Default Data Set
+            #
+            twoStepFlag 1
+            slaveOnly 0
+            priority1 128
+            priority2 128
+            domainNumber 24
+            #utc_offset 37
+            clockClass 248
+            clockAccuracy 0xFE
+            offsetScaledLogVariance 0xFFFF
+            free_running 0
+            freq_est_interval 1
+            dscp_event 0
+            dscp_general 0
+            #dataset_comparison ieee1588
+            dataset_comparison G.8275.x
+            G.8275.defaultDS.localPriority 128
+            #
+            # Port Data Set
+            #
+            logAnnounceInterval -3
+            logSyncInterval -4
+            logMinDelayReqInterval -4
+            logMinPdelayReqInterval -4
+            announceReceiptTimeout 3
+            syncReceiptTimeout 0
+            delayAsymmetry 0
+            fault_reset_interval 4
+            neighborPropDelayThresh 20000000
+            masterOnly 1
+            G.8275.portDS.localPriority 128
+            #
+            # Run time options
+            #
+            assume_two_step 0
+            logging_level 6
+            path_trace_enabled 0
+            follow_up_info 0
+            hybrid_e2e 0
+            inhibit_multicast_service 0
+            net_sync_monitor 0
+            tc_spanning_tree 0
+            tx_timestamp_timeout 50
+            unicast_listen 0
+            unicast_master_table 0
+            unicast_req_duration 3600
+            use_syslog 1
+            verbose 1
+            summary_interval 0
+            kernel_leap 1
+            check_fup_sync 0
+            #
+            # Servo Options
+            #
+            pi_proportional_const 0.0
+            pi_integral_const 0.0
+            pi_proportional_scale 0.0
+            pi_proportional_exponent -0.3
+            pi_proportional_norm_max 0.7
+            pi_integral_scale 0.0
+            pi_integral_exponent 0.4
+            pi_integral_norm_max 0.3
+            step_threshold 0.0
+            first_step_threshold 0.00002
+            max_frequency 900000000
+            #clock_servo pi
+            clock_servo linreg
+            sanity_freq_limit 200000000
+            ntpshm_segment 0
+            #
+            # Transport options
+            #
+            transportSpecific 0x0
+            ptp_dst_mac 01:1B:19:00:00:00
+            p2p_dst_mac 01:80:C2:00:00:0E
+            udp_ttl 1
+            udp6_scope 0x0E
+            uds_address /var/run/ptp4l
+            #
+            # Default interface options
+            #
+            clock_type OC
+            network_transport L2
+            delay_mechanism E2E
+            time_stamping hardware
+            tsproc_mode filter
+            delay_filter moving_median
+            delay_filter_length 10
+            egressLatency 0
+            ingressLatency 0
+            boundary_clock_jbod 0
+            #
+            # Clock description
+            #
+            productDescription ;;
+            revisionData ;;
+            manufacturerIdentity 00:00:00
+            userDescription ;
+            timeSource 0xA0
+          ts2phcConf: |
+            [nmea]
+            ts2phc.master 1
+            [global]
+            use_syslog  0
+            verbose 1
+            logging_level 7
+            ts2phc.pulsewidth 100000000
+            #GNSS module s /dev/ttyGNSS* -al use _0
+            #cat /dev/ttyGNSS_1700_0 to find available serial port
+            #example value of gnss_serialport is /dev/ttyGNSS_1700_0
+            ts2phc.nmea_serialport /gpsd/data
+            leapfile  /usr/share/zoneinfo/leap-seconds.list
+            [ens6f0]
+            ts2phc.extts_polarity rising
+            ts2phc.extts_correction 0
 #    - fileName: PtpConfigSlave.yaml   # Change to PtpConfigSlaveCvl.yaml for ColumbiaVille NIC
 #      policyName: "config-policy"
 #      metadata:
@@ -49,6 +181,35 @@ spec:
 #          interface: "ens5f0"
 #          ptp4lOpts: "-2 -s --summary_interval -4"
 #          phc2sysOpts: "-a -r -n 24"
+    - fileName: SriovFecClusterConfig.yaml
+      policyName: "fec-policy"
+      spec:
+        drainSkip: true
+        acceleratorSelector:
+          pciAddress: 0000:c3:00.0
+        physicalFunction:
+         bbDevConfig:
+          acc100:
+            # Programming mode: 0 = VF Programming, 1 = PF Programming
+            pfMode: false
+            numVfBundles: 16
+            maxQueueSize: 1024
+            uplink4G:
+              numQueueGroups: 0
+              numAqsPerGroups: 16
+              aqDepthLog2: 4
+            downlink4G:
+              numQueueGroups: 0
+              numAqsPerGroups: 16
+              aqDepthLog2: 4
+            uplink5G:
+              numQueueGroups: 4
+              numAqsPerGroups: 16
+              aqDepthLog2: 4
+            downlink5G:
+              numQueueGroups: 4
+              numAqsPerGroups: 16
+              aqDepthLog2: 4
     - fileName: SriovOperatorConfig.yaml
       policyName: "config-policy"
       # For existing clusters with node selector set as "master", 

--- a/clusters/ztp-policies/common/group-policies/group-smcx12-vse2.yaml
+++ b/clusters/ztp-policies/common/group-policies/group-smcx12-vse2.yaml
@@ -52,6 +52,12 @@ spec:
           ptp4lConf: |
             [ens6f0]
             masterOnly 1
+            [ens6f1]
+            masterOnly 1
+            [ens6f2]
+            masterOnly 1
+            [ens6f3]
+            masterOnly 1
             [global]
             #
             # Default Data Set

--- a/clusters/ztp-policies/common/group-policies/group-smcx12-vse2.yaml
+++ b/clusters/ztp-policies/common/group-policies/group-smcx12-vse2.yaml
@@ -165,7 +165,7 @@ spec:
             #GNSS module s /dev/ttyGNSS* -al use _0
             #cat /dev/ttyGNSS_1700_0 to find available serial port
             #example value of gnss_serialport is /dev/ttyGNSS_1700_0
-            ts2phc.nmea_serialport /gpsd/data
+            ts2phc.nmea_serialport /dev/gnss0
             leapfile  /usr/share/zoneinfo/leap-seconds.list
             [ens6f0]
             ts2phc.extts_polarity rising


### PR DESCRIPTION
This PR:

1. Adds XXVDA4T based ptp4l configuration for the OpenShift PTP Operator, responsible for acting as a Telecom Grandmaster (T-GM) to the group policy responsible for the VSE2 SKU in my lab.
2. Adds ACC100 based FEC acceleration policies to the group policy responsible for the VSE2 SKU in my lab.