### PR TITLE
redeploy falcon to use partner index

### DIFF
--- a/clusters/ztp-policies/common/kustomization.yaml
+++ b/clusters/ztp-policies/common/kustomization.yaml
@@ -12,8 +12,10 @@ resources:
 generators:
  # This is common to all RAN deployments
  - common-policies/common-ranGen.yaml
- # This is common to all VSE RAN DU deployments Testing 4.14
+ # This is common to all VSE RAN DU deployments Testing 4.14 using Dave's Index
  - common-policies/common-ranGen-vse414.yaml
+  # This is common to all PreGA RAN DU deployments using the Partner Index
+ - common-policies/common-ranGen-prega414.yaml
 
  # yamllint disable-line rule:line-length
  # This group policy is for all Dell R740 based deployments with SKU VSE-1:

--- a/clusters/ztp-siteconfig/falcon.cars2.lab/falcon-siteconfig.yaml
+++ b/clusters/ztp-siteconfig/falcon.cars2.lab/falcon-siteconfig.yaml
@@ -1,0 +1,141 @@
+---
+# yamllint disable rule:line-length
+# yamllint disable rule:comments-indentation
+apiVersion: ran.openshift.io/v1
+kind: SiteConfig
+metadata:
+  name: "falcon"
+  namespace: "falcon"
+spec:
+  baseDomain: "cars2.lab"
+  pullSecretRef:
+    name: "assisted-deployment-pull-secret"
+  clusterImageSetNameRef: "openshift-4.14.0-ec.4"
+  sshPublicKey: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDd7Jj5iFCWv9IHJK9H+2O3lyPs36moAxeAUiHvzRS3uzqGxxB33BnTRBNDKsoDFSGJX0J4bd5b+XyCPdhFOfvn/xhmAcm6d8GALS+139e8d+No8h2QgZy0OVJFp844k4nmz4wew5/+X9DN40ZURYerekbVc58hw1+rTu0uM2jQ0cE2QmEf3qGKHx9UJW8t6IsMzwnrikBH30sYqn2NcBE+/c8JzlLc3PvvenlY0iQkpukI1A5E9GGMR9OS/q+w6FH85zvSgUatOV7Q5lg45QUF+V77DrfX5+niI+NK1g70pRvD8481SAdXrHPB5vK4vQEmJ4pz83IKYHVuPzRnjzYKv1jV33oReyyMqyk44Rsfkxl4i5SJ9z7q/EVmTjvurzD6ofi3Dg0+PL18eTcjuPFdCxSCUFsnr5N9CRHCxHRQpxoZTD7sYD4jDGNygawLvhxcvgKGBZzP53NRCzRFOMFmZsLPLQRaNOsgKRPAohmrn5l8+1xG5ltVauOwAFlKUxk="
+  clusters:
+    - clusterName: "falcon"
+      networkType: "OVNKubernetes"
+      # installConfigOverrides is a generic way of passing install-config
+      # parameters through the siteConfig.  The 'capabilities' field configures
+      # the composable openshift feature.  In this 'capabilities' setting, we
+      # remove all but the marketplace component from the optional set of
+      # components.
+      # Notes:
+      # - NodeTuning is needed for 4.13 and later, not for 4.12 and earlier
+      installConfigOverrides: "{\"capabilities\":{\"baselineCapabilitySet\": \"None\", \"additionalEnabledCapabilities\": [ \"marketplace\", \"NodeTuning\" ] }}"
+      # It is strongly recommended to include crun manifests as part of the additional install-time manifests for 4.13+.
+      # The crun manifests can be obtained from source-crs/optional-extra-manifest/ and added to the git repo ie.sno-extra-manifest.
+      # extraManifestPath: sno-extra-manifest
+      clusterLabels:
+        common-du-prega414: true
+        group-smcx12-vse2: ""
+        sites: "falcon-cars2-lab"
+        vseloki: true
+        vseextras: true
+      clusterNetwork:
+        - cidr: 10.128.0.0/14
+          hostPrefix: 23
+        - cidr: fd01::/48
+          hostPrefix: 64
+      serviceNetwork:
+        - 172.30.0.0/16
+        - fd02::/112
+      machineNetwork:
+        - cidr: 192.168.38.128/26
+        - cidr: 2600:52:7:300::0/64
+      additionalNTPSources:
+        - clock.cars2.lab
+        - clock-v6.cars2.lab
+      #crTemplates:
+      #  KlusterletAddonConfig: "KlusterletAddonConfigOverride.yaml"
+      nodes:
+        - hostName: "du1-2.falcon.cars2.lab"
+          role: master
+          # Optionally; This can be used to configure desired BIOS setting on a host:
+          #biosConfigRef:
+          #  filePath: "example-hw.profile"
+          bmcAddress: "redfish-virtualmedia://192.168.38.200/redfish/v1/Systems/1/"
+          bmcCredentialsName:
+            name: "du1-2-falcon-cars2-lab-bmc-secret"
+          bootMACAddress: "3c:ec:ef:b6:ce:f2"
+          bootMode: "UEFI"
+          rootDeviceHints:
+            wwn: "0x500a075138277ae5"
+          # example of diskPartition below is used for image registry (check ImageRegistry.md for more details), but it's not limited to this use case
+#          diskPartition:
+#            - device: /dev/disk/by-id/wwn-0x11111000000asd123 # match rootDeviceHints
+#              partitions:
+#                - mount_point: /var/imageregistry
+#                  size: 102500
+#                  start: 344844
+         # allocate partitions for persist storage used by HTTP transport subscription data for PTP and BMER operators.
+         # disk id and and size needs to be adjusted to the hardware
+         # ignitionConfigOverride: '{"ignition":{"version":"3.2.0"},"storage":{"disks":[{"device":"/dev/disk/by-id/wwn-0x11111000000asd123","wipeTable":false,"partitions":[{"sizeMiB":16,"label":"httpevent1","startMiB":350000},{"sizeMiB":16,"label":"httpevent2","startMiB":350016}]}],"filesystem":[{"device":"/dev/disk/by-partlabel/httpevent1","format":"xfs","wipeFilesystem":true},{"device":"/dev/disk/by-partlabel/httpevent2","format":"xfs","wipeFilesystem":true}]}}'
+          cpuset: "0-1,33-34" # match the value with PerformanceProfile's .spec.cpu.reserved for workload partitioning.
+          nodeNetwork:
+            interfaces:
+              - name: eno1
+                macAddress: "3c:ec:ef:b6:ce:f0"
+              - name: eno2
+                macAddress: "3c:ec:ef:b6:ce:f1"
+              - name: eno3
+                macAddress: "3c:ec:ef:b6:ce:f2"
+              - name: ens6f0
+                macAddress: "50:7c:6f:30:fb:e8"
+              - name: ens6f1
+                macAddress: "50:7c:6f:30:fb:e9"
+              - name: ens6f2
+                macAddress: "50:7c:6f:30:fb:ea"
+              - name: ens6f3
+                macAddress: "50:7c:6f:30:fb:eb"
+            config:
+              interfaces:
+                - name: eno1
+                  type: ethernet
+                  state: down
+                - name: eno2
+                  type: ethernet
+                  state: down
+                - name: eno3
+                  type: ethernet
+                  state: up
+                  ipv4:
+                    enabled: true
+                    address:
+                      - ip: "192.168.38.143"
+                        prefix-length: 26
+                    dhcp: false
+                  ipv6:
+                    enabled: true
+                    address:
+                      - ip: "2600:52:7:300::143"
+                        prefix-length: 64
+                    autoconf: false
+                    dhcp: false
+                - name: ens6f0
+                  type: ethernet
+                  state: down
+                - name: ens6f1
+                  type: ethernet
+                  state: down
+                - name: ens6f2
+                  type: ethernet
+                  state: down
+                - name: ens6f3
+                  type: ethernet
+                  state: down
+              dns-resolver:
+                config:
+                  search:
+                    - cars2.lab
+                  server:
+                    - 192.168.38.12
+                    - 2600:52:7:38::12
+              routes:
+                config:
+                  - destination: 0.0.0.0/0
+                    next-hop-address: 192.168.38.129
+                    next-hop-interface: eno3
+                  - destination: ::/0
+                    next-hop-address: 2600:52:7:300::1
+                    next-hop-interface: eno3

--- a/clusters/ztp-siteconfig/falcon.cars2.lab/kustomization.yaml
+++ b/clusters/ztp-siteconfig/falcon.cars2.lab/kustomization.yaml
@@ -1,0 +1,47 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+generators:
+ - falcon-siteconfig.yaml
+
+resources:
+ - github.com/redhat-partner-solutions/vse-ocp-bases/base/ztp/site-config?ref=main
+
+patches:
+ - target:
+    kind: Secret
+   patch: |-
+     - op: replace
+       path: /metadata/name
+       value: 'du1-2-falcon-cars2-lab-bmc-secret'
+     - op: replace
+       path: /metadata/namespace
+       value: 'falcon'
+     - op: replace
+       path: /data/username
+       value: 'QURNSU4='
+     - op: replace
+       path: /data/password
+       value: 'UmVkSGF0VGVsY28hMjM0'
+ - target:
+    kind: SealedSecret
+   # yamllint disable rule:line-length
+   patch: |-
+     - op: replace
+       path: /metadata/name
+       value: 'assisted-deployment-pull-secret'
+     - op: replace
+       path: /metadata/namespace
+       value: 'falcon'
+     - op: replace
+       path: /spec/encryptedData/.dockerconfigjson
+       value: 'AgDCRoMrl0J1A1Ev7pl8ybdoAYyttOf9XHvHiaKRJjvpQbncncXNzze1LqiJEGbkxTh2562j7HRQcQ6an0iUPyqqwp3zxa5VjZhDsYdf/gAzkm1nuzgqPZLYRd7uOb/sYgrrVQqoEV+wXH0z3+6A5TtXaaTSvgODDJ8oW4oEH8LhcMqwRZWvTwQdu1HW+rVSnWJEpNsoQ4KqCKCGiNHRmKLLGjKR8frgp/JkooSpfTi3gBJ3OnxGb84KFUBYF1nJjDc6Hy1qftnHMRDZDKMSHjMXCI/UwJnBmUUGFJgX7G/jg8tvg+yATivKjSQqXGublWHiUFIMibViEtyrkEHK7cEpG/fGPkJ77WufWF/E93Rmm7ezR2bF9bcoBH60nrNROXliKE+MZ26J0lYcWZQvk8HLjCgMqhhTEyGRF8Xykn75cHbIr7bl+Ov4uae9nIH8GNbNAbjWWb4hSKr3EmNOB9R2K3/qfLWU6G6ZCl5LUyTl/7xP2swPdQflEoRi8PUWleCMAucmChNbQfPVhJF5IjpL8mf883l/ncD4jJnXIXziNuY2aOlBxC0gQZZpKKlEAULksYGjAMtfSml7bTtx37d92wjbTcRmosLKxbh41XS13KGsxaGXe4+ofvuzpBi4mcDtdRs2MXsA8YT3eHCJu5qHRD9ZD2E4sUkoiUMFGAf0xa3q6yLEiqKEdEKBvDMMyho+aGxeL/47XYpAmc9VA0qn8C0AfRw4B3Ng99NnetcCcgcHhkDYCWKhxMWlvx3NXH/PqE6f4rNp01hxG0DNOJ04Uf59Mt3FpgRbKRCaIlGNPmdcHPIybiQIsCNGpJuhmyFOkyEGhxd3Y8B23IIjH2RES8MjI2/q6/5TgLjk1Ta9aCnaol/C/apLhtC4XC01k+rBUibg6C/1HOboPNbnhE9yk4UHTxbubOfTxU7NGkFV/J/vipGJy7VC0f6Xn2I/kR+ZXKvel7Emhklq8CzQHQu+5PD6eMu1ejURKxdkMMbeBnjSTy872pxkD+8cCPOdphp1vy9nYt7M9jRX3e3SpF6AAG10kLysnWCTDUXw/CudVA1PKST3+Y7pyDDWxxkGkO7HMA7cQh2PTgf4lQVtqqaZh8s3EGPgKE8Vhslf8J9uHBWVtuVOJ/xkYzfzEyZZK/ouJKaUWFLQRyAr1OVh3LfCRQoxzFpp98rh3bHlz/lXUBti1grJNL1aoXug8b+YJiLDv0Qo3ucfPFbfK8ITRDeu1dtxBwFGFJdmIZUhNThdGGzZZXOX2817jkvD8roDIkuzypNZrPjRo9bdw9hnqRlQFk8rGbObzvCfjAW4gFJddYEZK3jJknwaoO/hblDwwZ9niM2Kqr13jXzyqcMNxV16dmjzaFCNtNytZuuzzyNE+qBRndP+MN54mqOHw2B1X9EH5IN0O/OU2khv5OVQlKSMb6H5tEcc4aZ69nCl+0bvTxF2ktTKQePTGx5S5nA4XkUbwsWGRJAMnTDMh55SPjfA/ciDv64ABGDjQyY6OxNq/oIjeets0FbE99GaU9GrukXDZRZxLKK1/6v9uuEkuokzz/sCXLY4PlPTWsB3K3uNpu9/miEcbgeZUO8LBEwZ6s6J7d3RfHrscsV83OqAN6FIwuZ+ldl5qDYsc9BwYfmCIDfTyMv7xBY222Ymy8us6mT7CVJjt9MAZC7GZL0xPE1QDBwMuFQh7HwCm1N1KUgIjLafTQoVMEsxvM/Qir5Xm7L9BmM4fgBagG9TS81mcLfG0kFE6Wv/ji3CNfoDVIrEg2l73YRXBlDjNMxqmuSsVsh1J5HqIlC0rnr6O55d6TzMyTOfjvGkt8csw+wo9bXW3Dshf67LqxsrHeVnVplIVw0+k7dFKBuI+0svS9elT/r8XgRKUS+NGNbZgP7GS3UQV2LNFYnZTkJzlBtpBpfekjPq1qd5MIPt+j+vAWpAP91NhyM+YoJwcw17LaR6ESayb4PDzDObdyHo+7DVoqB42kjxNayVBnalQn/54WjU8bEb1sfCkCREaboHZ2+edZhzb+sOslaV+ajQ7LbWqdoXpwGHzMEGpvVjudgz9EKgd3Z0GLbNK+0ckeDlIgLmaaIrujI79/7NLwUIXPcISSTK0hIPLKDXeJ5mQmAUorRiELe0d+rLXfT5r2x8fY5JiVHia+1UuwSThBBdb7w1aKCozvgaHzF653OApIoMiEDRgzUWCdML0xkW+JbVENSI1rPNAO1bHW1m0hrCE1G+yC9MG1yA8mBNLzQgLDUGFee9hNJzG4EVLZM1UHurciLhaAr4hveBKUOU78t3VBgRqeSILLYR4Y4hSm/jsSUkGqMBTz3jd/2JM+Nrt6JlpKkmt5P6DY52CidWbllTvT5Fnzzw7ypPFq75jE0eiscaNirv79MAWKwYj89TayhhIaO7dnIPOSqlF7tjPbh4fhkb8S7SCPG7hGzw5km7jJp66vxBveM+OmEXBK2gWkuw6uT7cxEsD5fbc0Ett7jIh+M9B+atUEEvZy4+35KXb39FOEeF/a805MGLAJKjdqp/ciSbjmfa77y2BRjJUT/d6oPGd2SkHM4gF6syNJeGW1oz9r/iJw81SSL3j8thAn5rvHBs5/icIVzLCtQHoX3mD5tuTjtXaO0YMYgN1DGKKd7von6Y8+Bmdj2RJ/eGHF30VDI6NPXFsj5IhwOSr2vJqOxyGw0trxRVLuDlaVv3T/Zye04D/sz8fH/wVemjgFlTbzywkkKyZubGQmdOTLvXWObSr4K6Sp47ToQE0Al4eIFh+h1z0QZu0KqE15fwBoYnkbXe9NsyNwHOF2PD12NGH7Luo9v2ZB+cP7bgWGFOI9mw66v3VJOL/EbayIzb5zeOuw3FDOtyXknxr3qWv+aKYFur8NVE49oGEUjy9o86O+r/YGK6PyOypYcymBNaLDYmLXM7odwyKixpY0VEXsq+5VVpzAa0xUL8CLEhQEr3LNBm1Cpeu43RsY6aHt+1za+N/DMRaYiSvib6Wbdw9P9kEmcgnoQ643eXIlfmPQTcnCKkTO/dGUW+fOolnkT4eGjtNEaaERlidSHle7mPwogqA+28p/DXjO3D/t7hmN48W/LCEBXC67sv+gqgA5EWZnKoRn9AZrBfw8CGJbwkljfoSpr+uC2o8ATM4E6mSEZo7v5XRXVEb9D/QgMQD1WtOc3sI8jZlrF5OwbcyXDk4wuItv9AuWdgrFuQ0zSEtINYDZ4y0WCFEfr1e4PykRX8gMHVuuKeDBCKSVeur4fnL4bXLrttCNajWhwYJcNFcvxNFaCeoUX5zngA0iDqLX0Ui+cvIuAVWWNk2ETAmxbDnY6gbQflTlWpaEo6u6IXU5Dx8YleNksim+S2YbptO35j2CPcabRZrxqKD2+BdwdWXjyazk2WksxOYJ+on5JvvkccNZr38Kr+FwKrKqqeFM8GzSugw0wLegs5RoUojSwCsahABMxJ++5IOIFU58DvWHAboolmTeQOEqxSNDLzCsLt8lrf+KOMf4ZTC6dp2hmfj3pzglmrSh6Zc/XBswDR35wwAfThor1wkrpr88jU1eL8HSx+DXbN9eAzB8u3Zvkme1Bdt8trhVMi2KvwObF0g4bSosveaZNr5GkRsxRZCgkdXjI86rGypK4mkQzaKAmv8cVU3IM/6xbH9jp20ZvcjLiuNxAVBLgp+9eLW8HlU3Cq9YywKlh33H3rOaI/TfEDssqawQNJsUlzoUMoSBGefIExaTjZ8T123SHc99s6poF9Pd8ODDuWhuHt6XzBqYup3gtCBzpienJm8W650iZFTH6ziMIzi8EnWzmXYNGY+b26n5KWAsUgrQFznfgckLXDXVuJLvZsUTq0I+g28I0b/zjPMTnnCEfBA158ABgeIWIaiQ5QQDAZ+npI7JFO5bIOeEqLbgVWZZbwyheyWD5X07nN18W8JpnYA0YK0M5j2NpQOxqlE8A//Yw2gbZTOurFUqZD+E1FcNubI0pdBpMyWsAJkchi3ZxMAzsIgUdHssmhFo0IAGtJc4ado3OzdeKLr9IwOz3ncTJtZ6JysPv2tJk+3BcovM0lb9BwQxOSZCCbKqPAzksVbWM8VESOVvzOb4mfp7S5qhe+Mf+hpuDFfZXdBDJchr5Ek49coXF2glc1UQyJ5Z9gIKm9XW37Tea5KfX8lXf23PKYiF4tm0jIw16aECfXsBDPs6F+H+V/w8qpJU9S1X7CiYjnrhw4QAh+oXx7eBlywzSUhIeF4vz1QynlY9CZ3+EP6xUlH3SjQ8r/iE5Vpj/e9w2e3JTUY2OnyopkA+CkErrKp4CkC7iB0g7kLo/PrxpRjlrr9sgAALT7bFu2zlxG1yYS7nziLYf7/h7aEbW1T7LsTkFF71AJfova64onIKJ8unb8AiGnvLuUoBMu2dJuZsMVqtbrf4dtUxwCUl8JX2MWaWXhpc/TyW6pW9lz//fjNYWnPmBGre6xlubJ5bsaF2Xy8AN1/t5Hwdyoi9oT77f5zEjQPtf1k2cXUTk78jLKC6HAvMLdubk5o3svhHGzTzdb5iy21790mu9KMYDrXzEUv0MDwe/XjvEGjfjyF2uY5EOawCI+cpQYkCCVY847MkT7g+j0LUg5d//QbpfvU8Dsh2FSBab4PkKNl8bxBZoOnFTC4WM6lfT299NDBaeCf33GRQcSUqG/Lv7jgt4UrR+8g+AC/riEazwwXM1AUNNeRD+pfEs2gbmQjv3FB3lXGei8fdEAXLL0LsdeOcpJnWD/qd0A00pawIv3tsGp7xMpN1kQPKP2DymqxDGsgeJHdKY='
+     - op: replace
+       path: /spec/encryptedData/type
+     - op: replace
+       path: /spec/template/metadata/name
+       value: 'du1-2-falcon-cars2-lab-bmc-secret'
+     - op: replace
+       path: /spec/template/metadata/namespace
+       value: 'falcon'


### PR DESCRIPTION
This PR redeploys the Falcon cluster.  Changes are:

1. Falcon uses the Partner index
2. Falcon will move to the PTP operator version ptp-operator.v4.14.0-202308240205.