### PR TITLE
stage updates for rhcos image updates and rc.0 to main

### DIFF
--- a/core/advanced-cluster-management/02-agentserviceconfig.yaml
+++ b/core/advanced-cluster-management/02-agentserviceconfig.yaml
@@ -61,29 +61,29 @@ spec:
       # yamllint enable rule:line-length
     - openshiftVersion: "4.11"
       cpuArchitecture: x86_64
-      version: "411.86.202210072320-0"
+      version: "411.86.202308170928-0"
       # yamllint disable rule:line-length
-      url: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.11/4.11.9/rhcos-4.11.9-x86_64-live.x86_64.iso
-      rootFSUrl: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.11/4.11.9/rhcos-4.11.9-x86_64-live-rootfs.x86_64.img
+      url: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.11/4.11.48/rhcos-4.11.48-x86_64-live.x86_64.iso
+      rootFSUrl: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.11/4.11.48/rhcos-4.11.48-x86_64-live-rootfs.x86_64.img
       # yamllint enable rule:line-length
     - openshiftVersion: "4.12"
       cpuArchitecture: x86_64
-      version: "412.86.202305030814-0"
+      version: "412.86.202308161343-0"
       # yamllint disable rule:line-length
-      url: https://mirror.openshift.com/pub/openshift-v4/amd64/dependencies/rhcos/4.12/4.12.17/rhcos-4.12.17-x86_64-live.x86_64.iso
-      rootFSUrl: https://mirror.openshift.com/pub/openshift-v4/amd64/dependencies/rhcos/4.12/4.12.17/rhcos-4.12.17-x86_64-live-rootfs.x86_64.img
+      url: https://mirror.openshift.com/pub/openshift-v4/amd64/dependencies/rhcos/4.12/4.12.30/rhcos-4.12.30-x86_64-live.x86_64.iso
+      rootFSUrl: https://mirror.openshift.com/pub/openshift-v4/amd64/dependencies/rhcos/4.12/4.12.30/rhcos-4.12.30-x86_64-live-rootfs.x86_64.img
       # yamllint enable rule:line-length
     - openshiftVersion: "4.13"
       cpuArchitecture: x86_64
-      version: "413.92.202307140015-0"
+      version: "413.92.202308210212-0"
       # yamllint disable rule:line-length
-      url: https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/4.13/4.13.5/rhcos-4.13.5-x86_64-live.x86_64.iso
-      rootFSUrl: https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/4.13/4.13.5/rhcos-4.13.5-x86_64-live-rootfs.x86_64.img
+      url: https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/4.13/4.13.10/rhcos-4.13.10-x86_64-live.x86_64.iso
+      rootFSUrl: https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/4.13/4.13.10/rhcos-4.13.10-x86_64-live-rootfs.x86_64.img
       # yamllint enable rule:line-length
     - openshiftVersion: "4.14"
       cpuArchitecture: x86_64
-      version: "414.92.202306100411-0"
+      version: "414.92.202308311551-0"
       # yamllint disable rule:line-length
-      url: https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/pre-release/latest-4.14/rhcos-4.14.0-ec.2-x86_64-live.x86_64.iso
-      rootFSUrl: https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/pre-release/latest-4.14/rhcos-4.14.0-ec.2-x86_64-live-rootfs.x86_64.img
+      url: https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/pre-release/latest-4.14/rhcos-4.14.0-rc.0-x86_64-live.x86_64.iso
+      rootFSUrl: https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/pre-release/latest-4.14/rhcos-4.14.0-rc.0-x86_64-live-rootfs.x86_64.img
       # yamllint enable rule:line-length

--- a/core/advanced-cluster-management/03-clusterimageset.yaml
+++ b/core/advanced-cluster-management/03-clusterimageset.yaml
@@ -2,29 +2,19 @@
 apiVersion: hive.openshift.io/v1
 kind: ClusterImageSet
 metadata:
-  name: openshift-v4.8.43
-  annotations:
-    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
-    argocd.argoproj.io/sync-wave: "3"
-spec:
-  releaseImage: quay.io/openshift-release-dev/ocp-release:4.8.43-x86_64
----
-apiVersion: hive.openshift.io/v1
-kind: ClusterImageSet
-metadata:
-  name: openshift-v4.9.45
-  annotations:
-    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
-    argocd.argoproj.io/sync-wave: "3"
-spec:
-  releaseImage: quay.io/openshift-release-dev/ocp-release:4.9.45-x86_64
----
-apiVersion: hive.openshift.io/v1
-kind: ClusterImageSet
-metadata:
   name: openshift-v4.10.37
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: "3"
 spec:
   releaseImage: quay.io/openshift-release-dev/ocp-release:4.10.37-x86_64
+---
+apiVersion: hive.openshift.io/v1
+kind: ClusterImageSet
+metadata:
+  name: openshift-v4.14.0-rc.0
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "3"
+spec:
+  releaseImage: quay.io/openshift-release-dev/ocp-release:4.14.0-rc.0-x86_64


### PR DESCRIPTION
This PR:

1. Updates the 4.11, 4.12, 4.13, and 4.14 RHCOS live and ISO images to their latest counterparts.  These releases are a more recent version hosted on the OpenShift mirror site (mirror.openshift.com) and represent three+ months of RHEL fixes (in some cases) and should be used as a base vs their older counterparts during the provisioning process.
2. refreshes OpenShift ClusterImageSet to add 4.14 rc.0 and remove no longer supported versions.  Customers and partners should also try to stay current with enhancements and security fixes present in these newer versions.

On (1), we will keep 4.8 through 4.9 ISO images for now for historical purposes.