### PR TITLE
3oct deploy bronco and falcon with rc.3

### DIFF
--- a/clusters/ztp-policies/common/common-policies/common-ranGen-prega414-latest.yaml
+++ b/clusters/ztp-policies/common/common-policies/common-ranGen-prega414-latest.yaml
@@ -60,7 +60,7 @@ spec:
       spec:
         displayName: Telco 4.14 PreGA Latest
         # yamllint disable rule:line-length
-        image: quay.io/prega/test/prega/redhat-operator-index:v4.14-20230918T143957
+        image: quay.io/prega/redhat-operator-index:v4.14
         updateStrategy:
           registryPoll:
             interval: 10m0s

--- a/clusters/ztp-policies/common/common-policies/common-ranGen-prega414.yaml
+++ b/clusters/ztp-policies/common/common-policies/common-ranGen-prega414.yaml
@@ -12,8 +12,6 @@ spec:
     # Create operators policies that will be installed in all clusters
     - fileName: SriovSubscription.yaml
       policyName: "subscriptions-policy"
-      spec:
-        channel: "4.14"
     - fileName: SriovSubscriptionNS.yaml
       policyName: "subscriptions-policy"
     - fileName: SriovSubscriptionOperGroup.yaml
@@ -60,9 +58,9 @@ spec:
       metadata:
         name: redhat-operators
       spec:
-        displayName: Telco 4.14 PreGA Official
+        displayName: Telco 4.14 PreGA Sep18
         # yamllint disable rule:line-length
-        image: quay.io/prega/redhat-operator-index:v4.14
+        image: quay.io/prega/test/prega/redhat-operator-index:v4.14-20230918T143957
         updateStrategy:
           registryPoll:
             interval: 10m0s

--- a/clusters/ztp-siteconfig/bronco.cars2.lab/bronco-siteconfig.yaml
+++ b/clusters/ztp-siteconfig/bronco.cars2.lab/bronco-siteconfig.yaml
@@ -1,0 +1,160 @@
+---
+# yamllint disable rule:line-length
+# yamllint disable rule:comments-indentation
+apiVersion: ran.openshift.io/v1
+kind: SiteConfig
+metadata:
+  name: "bronco"
+  namespace: "bronco"
+spec:
+  baseDomain: "cars2.lab"
+  pullSecretRef:
+    name: "assisted-deployment-pull-secret"
+  clusterImageSetNameRef: "openshift-4.14.0-rc.3"
+  sshPublicKey: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDd7Jj5iFCWv9IHJK9H+2O3lyPs36moAxeAUiHvzRS3uzqGxxB33BnTRBNDKsoDFSGJX0J4bd5b+XyCPdhFOfvn/xhmAcm6d8GALS+139e8d+No8h2QgZy0OVJFp844k4nmz4wew5/+X9DN40ZURYerekbVc58hw1+rTu0uM2jQ0cE2QmEf3qGKHx9UJW8t6IsMzwnrikBH30sYqn2NcBE+/c8JzlLc3PvvenlY0iQkpukI1A5E9GGMR9OS/q+w6FH85zvSgUatOV7Q5lg45QUF+V77DrfX5+niI+NK1g70pRvD8481SAdXrHPB5vK4vQEmJ4pz83IKYHVuPzRnjzYKv1jV33oReyyMqyk44Rsfkxl4i5SJ9z7q/EVmTjvurzD6ofi3Dg0+PL18eTcjuPFdCxSCUFsnr5N9CRHCxHRQpxoZTD7sYD4jDGNygawLvhxcvgKGBZzP53NRCzRFOMFmZsLPLQRaNOsgKRPAohmrn5l8+1xG5ltVauOwAFlKUxk="
+  clusters:
+    - clusterName: "bronco"
+      networkType: "OVNKubernetes"
+      cpuPartitioningMode: AllNodes
+      # installConfigOverrides is a generic way of passing install-config
+      # parameters through the siteConfig.  The 'capabilities' field configures
+      # the composable openshift feature.  In this 'capabilities' setting, we
+      # remove all but the marketplace component from the optional set of
+      # components.
+      # Notes:
+      # - NodeTuning is needed for 4.13 and later, not for 4.12 and earlier
+      installConfigOverrides: "{\"capabilities\":{\"baselineCapabilitySet\": \"None\", \"additionalEnabledCapabilities\": [ \"marketplace\", \"NodeTuning\" ] }}"
+      # It is strongly recommended to include crun manifests as part of the additional install-time manifests for 4.13+.
+      # The crun manifests can be obtained from source-crs/optional-extra-manifest/ and added to the git repo ie.sno-extra-manifest.
+      # extraManifestPath: sno-extra-manifest
+      clusterLabels:
+        common-du-prega414-latest: true
+        group-dellr760-vse4: ""
+        vseextras: true
+      clusterNetwork:
+        - cidr: 10.128.0.0/14
+          hostPrefix: 23
+        - cidr: fd01::/48
+          hostPrefix: 64
+      serviceNetwork:
+        - 172.30.0.0/16
+        - fd02::/112
+      machineNetwork:
+        - cidr: 192.168.38.128/26
+        - cidr: 2600:52:7:300::0/64
+      additionalNTPSources:
+        - clock.cars2.lab
+        - clock-v6.cars2.lab
+      # Optionally; This can be used to override the KlusterletAddonConfig that is created for this cluster:
+      #crTemplates:
+      #  KlusterletAddonConfig: "KlusterletAddonConfigOverride.yaml"
+      #proxy:
+        #httpProxy: http://cars2-client.infra.cars2.lab:3128
+        #httpsProxy: http://cars2-client.infra.cars2.lab:3128
+        #noProxy: ".cars2.lab,2600:52:7:300::0/64,fd02::/112,fd01::/48,2600:52:7:38::0/64,2600:52:7:300::177,2600:52:7:300::179,2600:52:7:300::180,2600:52:7:300::181"
+      nodes:
+        - hostName: "spr760-1.bronco.cars2.lab"
+          role: "master"
+          # Optionally; This can be used to configure desired BIOS setting on a host:
+          #biosConfigRef:
+          #  filePath: "example-hw.profile"
+          bmcAddress: "idrac-virtualmedia://192.168.38.208/redfish/v1/Systems/System.Embedded.1"
+          bmcCredentialsName:
+            name: "bronco-bmc-creds-secret"
+          bootMACAddress: "ec:2a:72:51:31:b8"
+          # Use UEFISecureBoot to enable secure boot
+          bootMode: "UEFI"
+          rootDeviceHints:
+            deviceName: "/dev/sda"
+          # example of diskPartition below is used for image registry (check ImageRegistry.md for more details), but it's not limited to this use case
+#          diskPartition:
+#            - device: /dev/disk/by-id/wwn-0x11111000000asd123 # match rootDeviceHints
+#              partitions:
+#                - mount_point: /var/imageregistry
+#                  size: 102500
+#                  start: 344844
+         # allocate partitions for persist storage used by HTTP transport subscription data for PTP and BMER operators.
+         # disk id and and size needs to be adjusted to the hardware
+         # ignitionConfigOverride: '{"ignition":{"version":"3.2.0"},"storage":{"disks":[{"device":"/dev/disk/by-id/wwn-0x11111000000asd123","wipeTable":false,"partitions":[{"sizeMiB":16,"label":"httpevent1","startMiB":350000},{"sizeMiB":16,"label":"httpevent2","startMiB":350016}]}],"filesystem":[{"device":"/dev/disk/by-partlabel/httpevent1","format":"xfs","wipeFilesystem":true},{"device":"/dev/disk/by-partlabel/httpevent2","format":"xfs","wipeFilesystem":true}]}}'
+          nodeNetwork:
+            interfaces:
+              - name: eno8303
+                macAddress: "ec:2a:72:51:31:b8"
+              - name: eno8403
+                macAddress: "ec:2a:72:51:31:b9"
+              - name: eno12399
+                macAddress: "40:a6:b7:a8:79:c8"
+              - name: eno12409
+                macAddress: "40:a6:b7:a8:79:c9"
+              - name: eno12419
+                macAddress: "40:a6:b7:a8:79:ca"
+              - name: eno12429
+                macAddress: "40:a6:b7:a8:79:cb"
+              - name: ens2f0
+                macAddress: "50:7c:6f:1f:b3:98"
+              - name: ens2f1
+                macAddress: "50:7c:6f:1f:b3:99"
+              - name: ens2f2
+                macAddress: "50:7c:6f:1f:b3:9a"
+              - name: ens2f3
+                macAddress: "50:7c:6f:1f:b3:9b"
+            config:
+              interfaces:
+                - name: eno8303
+                  type: ethernet
+                  state: up
+                  ipv4:
+                    enabled: true
+                    address:
+                      - ip: "192.168.38.145"
+                        prefix-length: 26
+                    dhcp: false
+                  ipv6:
+                    enabled: true
+                    address:
+                      - ip: "2600:52:7:300::145"
+                        prefix-length: 64
+                    autoconf: false
+                    dhcp: false
+                - name: eno8403
+                  type: ethernet
+                  state: down
+                - name: eno12399
+                  type: ethernet
+                  state: up
+                - name: eno12409
+                  type: ethernet
+                  state: down
+                - name: eno12419
+                  type: ethernet
+                  state: down
+                - name: eno12429
+                  type: ethernet
+                  state: down
+                - name: ens2f0
+                  type: ethernet
+                  state: down
+                - name: ens2f1
+                  type: ethernet
+                  state: down
+                - name: ens2f2
+                  type: ethernet
+                  state: down
+                - name: ens2f3
+                  type: ethernet
+                  state: down
+              dns-resolver:
+                config:
+                  search:
+                    - cars2.lab
+                  server:
+                    - 192.168.38.12
+                    - 2600:52:7:38::12
+              routes:
+                config:
+                  - destination: 0.0.0.0/0
+                    next-hop-address: 192.168.38.129
+                    next-hop-interface: eno8303
+                  - destination: ::/0
+                    next-hop-address: 2600:52:7:300::1
+                    next-hop-interface: eno8303

--- a/clusters/ztp-siteconfig/bronco.cars2.lab/kustomization.yaml
+++ b/clusters/ztp-siteconfig/bronco.cars2.lab/kustomization.yaml
@@ -1,0 +1,47 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+generators:
+ - bronco-siteconfig.yaml
+
+resources:
+ - github.com/redhat-partner-solutions/vse-ocp-bases/base/ztp/site-config?ref=main
+
+patches:
+ - target:
+    kind: Secret
+   patch: |-
+     - op: replace
+       path: /metadata/name
+       value: 'bronco-bmc-creds-secret'
+     - op: replace
+       path: /metadata/namespace
+       value: 'bronco'
+     - op: replace
+       path: /data/username
+       value: 'cm9vdA=='
+     - op: replace
+       path: /data/password
+       value: 'UmVkSGF0VGVsY28hMjM0'
+ - target:
+    kind: SealedSecret
+   # yamllint disable rule:line-length
+   patch: |-
+     - op: replace
+       path: /metadata/name
+       value: 'assisted-deployment-pull-secret'
+     - op: replace
+       path: /metadata/namespace
+       value: 'bronco'
+     - op: replace
+       path: /spec/encryptedData/.dockerconfigjson
+       value: 'AgB6WVvkNvdFvkISS0FeZk7bvHimMl00hQz1/QcvHqerzSPvcx9XRmC8aV1/nFLz39QByPMj2RIhkJ6touTezXFMZMjuyUOCF5uCfy0UniJAQhES/zJwB1pfcMUvJsvKyvKHSeI+LvwLLAfcJr5HlpVoCY48eMyWTQucNeyzeOm7BXgufy1feml9EQZWZ+RA15HSO3JFyuubz6U7CyfYGwfjhh025m/UnEERBcjIR663mo3HjhlYIfUFUwPyRdOOQG5UuZSN5YQlQb4IFsbg7W1/6+q73yaB8uDSGTRbpmbcT3Q2DqtcmzAgbMCSOamzUyzLfNwkFAP6lEXWZJV5HCbIS0v/5H605uwQD3yMirLNITJNMqAP0KWYrmB9JKN5+PfGRh2YvRMxT3KPDHPwSXQdoeb4/BFN9DdqaRQ3JC7PmUCfe1GgBRzo3v3WQ2+Rjm+Vkq6uCpB7YQM/4GccpwuatBioOIhd0q2q720Qc+M9unTo9QZOE797iPxIw0weaUStSWSchQ+iOiPGvejPq6hGswxs1pGyfee8dtBi4oNsIcFEeu+f+zh8Nb+VKhQcNaVGDgVBA2LV/6NklP6F2IiwKIanGM26rercOM8bSmZEwSL+miA9PXhpIES9BrwExAdCMKAptodom8x4BlGSb2ZiFUzNzqeLmbx8Pvf9f8Fm7DMSbmIKARI+IcNVdkpFzWEu8fHW9NiIJyYHd4MAFRHTedRFiiXurxUPg5USAOIYakfGdUdvwpIlVuLkYNL2PZ/geA9hlfpeVcxXm8vHt9IUuaWpPa/NqU7K2W0PQB52gbCisYEITHX2xKJMLFM0tMpptot1dXW7XkaJbK3oY2C2CBhx14dQWhqhL4JwvV3Fybnwq3vZXy5lg/aV76Pty9Oc8SxOo8syAr1OX8c5UZxVbwlQOnLOiyYMVYSbccrJKs5a2QDnjdzq+rB7z3qdjz22V61oo8iUkC/TaEHsaiPMH3tJMMrTmHlGiD/pZZ5I/m87xkv1FZF4a6yiJ6hDaTXxfxuYsy96HA8UsYCge6SuxzbLk55+makH/Nn8y5Svzvv0n5hS9UDBGrd1ERG3vnRG7sB7CkF93TM1J3YevLJgRClSlvKoCMjjfFk+ScT+e3UCfVu3nv20SP+GgDRjLmkQQBPoGZDAm9Q3WhRRAotOcRvofhMsqih7GRgKfDfYVZrl8AKS2BBQT0EVygyqNdKQ28c0VVIQoku1oBGjcqihwhmQD/AB75wQjWxXATPlc0nCm6M89vtgDFN7A8mxUUeJSOc46Nkhwy3CE/B3wOG7/0YFUCddirYMKvgBs7ys9HdpyrtsSG0mKSSFqjApkXk9EAruq2LkiTHOnDoUMOrnft4rEgKduMNAO8/IOhHQjkC6ITtfectJlwXf6We8qH/0pWx/OiXz9RONSzq3jWtdC5ky/LmfkBzQfIAMg3OqnP1TStVHNdvqNmbvdJigCzJjeoMhZKj7tFa+4BDPEUh+3PIjmEGYY2+CulLyVnemZhMd7dOHVBYyFnjcHaV5Sodr2XtD/StpiVIAoEpvlnVN2KBbIRATZMNAPQXitmJQCHdm6hKYUk1zoxCmCqPakT5H5yK1nijVoOMRXV2O22ecfxHFV+95R1Z4b6rcQJWmjJypuzXr74Lc09axDmcllb+kgnb6vukcH+hurIR5+IdRDPXxyV5KejII7JOUCek58XE5uQx2izzFYWZOoiyF7gbxOtXcWir1H2pzMcfoefcWCTppxhzB7AXEXuUoOUppx7UTB45nqs5LNygzagbagLxdaNnTSzFZ5eSVd4WJcMn3xBEKPdp3tc2zpuV084rNqcYsrK1qyaKaKOTIN/LCobm3iwNBXUCsXCeEkZ5IMzWIi0Dzxk/FTtL34rExE0WKIJxsTAoIJ3Uw72NcbGN3O/n+kyX9oFmFiaxm3h/flyTwZ0xwynWuA3pBy1mbU9dj+7d/o2harv591FFW3eKOgeQrLIlVk+8Qk8shlBgsi6kToxorHAktTmzeVxgLud4zVTrJ0j127KbxSPzNEf9Zr09ZzM7GRldLGU4l7ggaEemi0BlN8By/wvQ3whJrf3+avTW8wKB2nfmQYljSBRexeOHyst4L+SewlPiGTdcQmdDqPlHxpAhHX9C/kjbkuJJyagvDedfQzZbd0hrIEsO81AMdAcT4FxCoYv72LAA0UjIGisHBohJpxAv2oUOm7BTqY+4wNctV9n8Zi8wWP0LZoT//7ARxXhDxWUlYNVjXSSi71o+cPJHwbzFJFMSmm/ZqpOPTGd+q4OPQUookkwH+Q59rjycDaie9aVV7l01pOM0ECDs1+lvVtGa+ltM14ArUIwAyF61ijOVx/OYjc6JVMw1RMEhF+aMErqzWwDhQAReAbWgo8t35SXGTVG8xrWREtZPUvP//DlKt945vx/eNag9DPSL0HXgXz/jc9tXK5fUgO/uT9CRGpI4ub8pWS0Z3fgC1GJuuSXqq/CvHaBZlxnFn2lCv7x0+DdjT86M4+qalBpBYtzj10D8XaBvD19yGoQqdgubINeCgZztE/WcLiGt6B1SQhYexH+seLBv2gCWJBjZTWdAeGCuN2LESZNAUVQJu2vvhifzCt+eQ2qDhwiNdbBrZ8mXd0Whx2A08xjZaqV5FfzFEjhjBXPrHBIj/FqNdcZCkSIGj5MZXDWZYPp6aYg5wE6x3e8nUKLFm1DKbgTF9SILg+3g8ZC3uj1EO5n9e87Hz081sxIIhTzb7bXBF57zDUxyNSWco8wxOAg8ANNlvzvdnria7wYeUUUJ5/ZePwJApcLFl9o+APuUWexNJQjGii6maDge0YuhLa+x38KqPsZAcnRVPbtZBBDOfkUmuRmieX4r1+MzYtN/a5fzku7Y9jWuXsuXn1c7S5hjN57Hcot6Pj7P3maGvjggMOLHQws+wjbfBOkeAMN4WgiaLxzBQcuHpLJ0n4Myu9roZ9ilYTY3x3dwHLPrgfo9g1vq8di2TzKRKHsicrDhW5qU+eFh/SH+l6Z4oPmFvN+V0/5yt0F2rjvYVCgXa3/fYSZ9RU3fIWgM169qiTfZs62oK7AmCJJ4IC01YEfsVCXowttF/6u7ciRfCBIuWaf35Q/dd2EY+1cgZ35jk01pRMdEjO4AzQSlSYG7m+RAKqFDzIGoI/9OE2uA80zbNpcRtm5EIYP3/5eFNXNeQQbFAN2B1pjqUea9s/C0NkP+k1AoYItFIqskaF+0rkWmaW2sHMl27al/f80Cr7R+Jff5ZRFMhSUa4M9so0YbmiAAuPnKXUiPZL7k6ldykCryqgFmWyDx+NYng/ee0OjeIc6Tr4xyj5tmFZ+PyovX7RREpJgdOkuOLhsVGcP0rgROVyfeX+0loQmkMQ/PQdpMjAopD3X6W8ciloJ3YRYFGEnyzOpeA9Z0yHfUQ0yf6SPkpzS5SL3JUY0LL9kxECm17IEeHLN1A01TAM15SvrfVSGKhJGUhV4aS3cUMmt9/AARjp0L7Hbuto7y08xe5agKuCLURCor9NzvJKODVwHirigHpEwryl2B2RlEGE2XGeGXf4M+CZDp8obAjcue81OqhyAODtcH5SmKCt0I72UQdUbYaVY5PUZBX6tvlEF20n9BrsJyOnZ3Di7HcBQfWfyJTuZf7APecY/aLc4KRREwDF721bLejPBsm691oWaBH+dYuN8W/40OEKSKbT9XKgNdbvzdFNFb2I3LZXd8cbpe10AbmoJUSWxivBp19troItnNNN4/jnwcCgsZULAYuavYscPOr7kWsOSZZwRQCtBP7ubJuE54jRNI/rTSaIjIX52JDJM2YyOpcj4rw0PzC3Cg+z0xw8b/6HktAfAl+6rulhNRs6wjg3e5M2W61JzEtKp/+orp1WKvVOlV7QoPi7+AY6IJaB+NbuHJGpLGmQtey61prWCwH84cP15b1TsuSYG/T4TO+Fak96vP/ReBp7yPXuuz2vREDLTQeuq89NbHV4U5TZFDULK+pptfr9WjHsjvJUS5yjajBl6qmShgNerNOHkalPAT7alBV2lCeJrqZAbXS2hD/xzspAN8pHeuFG8cLZuv8ozmVDwa0H2DHSxWaXKa/jhn6ZqdPOmSuJfA7EXSuoJoPCjwgOg95ExbAZrDZ/fEf66FUf1a2zcSul/PJjVxYS+PPHiyCjZ3vlxfTXCnzpUiz9C9GA5rwo744OYvAneUtbkSJvzKyWMx/y4b/x3AbbIZ0VzIDNy3/4MVwoJhsG4qdFihlp4hhBv8kiJ9ssEvMrCA7i84izZ/IcdLjdAlLi5Jx77c3VMfdiKMlRc1ilRei9HSt9m5T7DfrSftjEGduopDtio9Nl6RFb9b6UTpyMqiZm+EKOBGNwyhVXqtv550d7GyegBPFdih67o/lvyfbMnxXYbwFWZrqCfL+EaBN3N275t1vzUJsVnZ4g4XW7SJr76c/1kVaLE6zlMcLDSiHREW021Vx1kamDWTBVIq8IptKVgUs3g02A1mMjjZJ6BymQWQ7v5Fi7zbCKdjM1Obh6L2/lPu9yJpNqoYtRKFNqkKQcqA6bRsKr9EOA0OPQVEe73eZ4jvkOYH2mZknsEq0rOIK+uhO9mD6Y0Pm8EwJRf9Vk/ijDXR18DDMqZS828DDG5NDvonAyBBX8UcjCU/NTCYJL7cdk/4HHtXg/v0kcjqGe/le0dnHg5843MP835bzNT0++K9WUo7J27nERqciYu9zN9+4k7ETt/Lxh7XhWn7Yw+zRa5fveyX8TJo3UF1YzjMGyY46fV2Sl8E2QIQ='
+     - op: replace
+       path: /spec/encryptedData/type
+     - op: replace
+       path: /spec/template/metadata/name
+       value: 'bronco-bmc-creds-secret'
+     - op: replace
+       path: /spec/template/metadata/namespace
+       value: 'bronco'

--- a/clusters/ztp-siteconfig/falcon.cars2.lab/falcon-siteconfig.yaml
+++ b/clusters/ztp-siteconfig/falcon.cars2.lab/falcon-siteconfig.yaml
@@ -1,0 +1,139 @@
+---
+# yamllint disable rule:line-length
+# yamllint disable rule:comments-indentation
+apiVersion: ran.openshift.io/v1
+kind: SiteConfig
+metadata:
+  name: "falcon"
+  namespace: "falcon"
+spec:
+  baseDomain: "cars2.lab"
+  pullSecretRef:
+    name: "assisted-deployment-pull-secret"
+  clusterImageSetNameRef: "openshift-4.14.0-rc.3"
+  sshPublicKey: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDd7Jj5iFCWv9IHJK9H+2O3lyPs36moAxeAUiHvzRS3uzqGxxB33BnTRBNDKsoDFSGJX0J4bd5b+XyCPdhFOfvn/xhmAcm6d8GALS+139e8d+No8h2QgZy0OVJFp844k4nmz4wew5/+X9DN40ZURYerekbVc58hw1+rTu0uM2jQ0cE2QmEf3qGKHx9UJW8t6IsMzwnrikBH30sYqn2NcBE+/c8JzlLc3PvvenlY0iQkpukI1A5E9GGMR9OS/q+w6FH85zvSgUatOV7Q5lg45QUF+V77DrfX5+niI+NK1g70pRvD8481SAdXrHPB5vK4vQEmJ4pz83IKYHVuPzRnjzYKv1jV33oReyyMqyk44Rsfkxl4i5SJ9z7q/EVmTjvurzD6ofi3Dg0+PL18eTcjuPFdCxSCUFsnr5N9CRHCxHRQpxoZTD7sYD4jDGNygawLvhxcvgKGBZzP53NRCzRFOMFmZsLPLQRaNOsgKRPAohmrn5l8+1xG5ltVauOwAFlKUxk="
+  clusters:
+    - clusterName: "falcon"
+      networkType: "OVNKubernetes"
+      cpuPartitioningMode: AllNodes
+      # installConfigOverrides is a generic way of passing install-config
+      # parameters through the siteConfig.  The 'capabilities' field configures
+      # the composable openshift feature.  In this 'capabilities' setting, we
+      # remove all but the marketplace component from the optional set of
+      # components.
+      # Notes:
+      # - NodeTuning is needed for 4.13 and later, not for 4.12 and earlier
+      installConfigOverrides: "{\"capabilities\":{\"baselineCapabilitySet\": \"None\", \"additionalEnabledCapabilities\": [ \"marketplace\", \"NodeTuning\" ] }}"
+      # It is strongly recommended to include crun manifests as part of the additional install-time manifests for 4.13+.
+      # The crun manifests can be obtained from source-crs/optional-extra-manifest/ and added to the git repo ie.sno-extra-manifest.
+      # extraManifestPath: sno-extra-manifest
+      clusterLabels:
+        common-du-prega414-latest: true
+        group-smcx12-vse2: ""
+        vseextras: true
+      clusterNetwork:
+        - cidr: 10.128.0.0/14
+          hostPrefix: 23
+        - cidr: fd01::/48
+          hostPrefix: 64
+      serviceNetwork:
+        - 172.30.0.0/16
+        - fd02::/112
+      machineNetwork:
+        - cidr: 192.168.38.128/26
+        - cidr: 2600:52:7:300::0/64
+      additionalNTPSources:
+        - clock.cars2.lab
+        - clock-v6.cars2.lab
+      #crTemplates:
+      #  KlusterletAddonConfig: "KlusterletAddonConfigOverride.yaml"
+      nodes:
+        - hostName: "du1-2.falcon.cars2.lab"
+          role: master
+          # Optionally; This can be used to configure desired BIOS setting on a host:
+          #biosConfigRef:
+          #  filePath: "example-hw.profile"
+          bmcAddress: "redfish-virtualmedia://192.168.38.200/redfish/v1/Systems/1/"
+          bmcCredentialsName:
+            name: "du1-2-falcon-cars2-lab-bmc-secret"
+          bootMACAddress: "3c:ec:ef:b6:ce:f2"
+          bootMode: "UEFI"
+          rootDeviceHints:
+            wwn: "0x500a075138277ae5"
+          # example of diskPartition below is used for image registry (check ImageRegistry.md for more details), but it's not limited to this use case
+#          diskPartition:
+#            - device: /dev/disk/by-id/wwn-0x11111000000asd123 # match rootDeviceHints
+#              partitions:
+#                - mount_point: /var/imageregistry
+#                  size: 102500
+#                  start: 344844
+         # allocate partitions for persist storage used by HTTP transport subscription data for PTP and BMER operators.
+         # disk id and and size needs to be adjusted to the hardware
+         # ignitionConfigOverride: '{"ignition":{"version":"3.2.0"},"storage":{"disks":[{"device":"/dev/disk/by-id/wwn-0x11111000000asd123","wipeTable":false,"partitions":[{"sizeMiB":16,"label":"httpevent1","startMiB":350000},{"sizeMiB":16,"label":"httpevent2","startMiB":350016}]}],"filesystem":[{"device":"/dev/disk/by-partlabel/httpevent1","format":"xfs","wipeFilesystem":true},{"device":"/dev/disk/by-partlabel/httpevent2","format":"xfs","wipeFilesystem":true}]}}'
+          nodeNetwork:
+            interfaces:
+              - name: eno1
+                macAddress: "3c:ec:ef:b6:ce:f0"
+              - name: eno2
+                macAddress: "3c:ec:ef:b6:ce:f1"
+              - name: eno3
+                macAddress: "3c:ec:ef:b6:ce:f2"
+              - name: ens6f0
+                macAddress: "50:7c:6f:30:fb:e8"
+              - name: ens6f1
+                macAddress: "50:7c:6f:30:fb:e9"
+              - name: ens6f2
+                macAddress: "50:7c:6f:30:fb:ea"
+              - name: ens6f3
+                macAddress: "50:7c:6f:30:fb:eb"
+            config:
+              interfaces:
+                - name: eno1
+                  type: ethernet
+                  state: down
+                - name: eno2
+                  type: ethernet
+                  state: down
+                - name: eno3
+                  type: ethernet
+                  state: up
+                  ipv4:
+                    enabled: true
+                    address:
+                      - ip: "192.168.38.143"
+                        prefix-length: 26
+                    dhcp: false
+                  ipv6:
+                    enabled: true
+                    address:
+                      - ip: "2600:52:7:300::143"
+                        prefix-length: 64
+                    autoconf: false
+                    dhcp: false
+                - name: ens6f0
+                  type: ethernet
+                  state: down
+                - name: ens6f1
+                  type: ethernet
+                  state: down
+                - name: ens6f2
+                  type: ethernet
+                  state: down
+                - name: ens6f3
+                  type: ethernet
+                  state: down
+              dns-resolver:
+                config:
+                  search:
+                    - cars2.lab
+                  server:
+                    - 192.168.38.12
+                    - 2600:52:7:38::12
+              routes:
+                config:
+                  - destination: 0.0.0.0/0
+                    next-hop-address: 192.168.38.129
+                    next-hop-interface: eno3
+                  - destination: ::/0
+                    next-hop-address: 2600:52:7:300::1
+                    next-hop-interface: eno3

--- a/clusters/ztp-siteconfig/falcon.cars2.lab/kustomization.yaml
+++ b/clusters/ztp-siteconfig/falcon.cars2.lab/kustomization.yaml
@@ -1,0 +1,47 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+generators:
+ - falcon-siteconfig.yaml
+
+resources:
+ - github.com/redhat-partner-solutions/vse-ocp-bases/base/ztp/site-config?ref=main
+
+patches:
+ - target:
+    kind: Secret
+   patch: |-
+     - op: replace
+       path: /metadata/name
+       value: 'du1-2-falcon-cars2-lab-bmc-secret'
+     - op: replace
+       path: /metadata/namespace
+       value: 'falcon'
+     - op: replace
+       path: /data/username
+       value: 'QURNSU4='
+     - op: replace
+       path: /data/password
+       value: 'UmVkSGF0VGVsY28hMjM0'
+ - target:
+    kind: SealedSecret
+   # yamllint disable rule:line-length
+   patch: |-
+     - op: replace
+       path: /metadata/name
+       value: 'assisted-deployment-pull-secret'
+     - op: replace
+       path: /metadata/namespace
+       value: 'falcon'
+     - op: replace
+       path: /spec/encryptedData/.dockerconfigjson
+       value: 'AgB6WVvkNvdFvkISS0FeZk7bvHimMl00hQz1/QcvHqerzSPvcx9XRmC8aV1/nFLz39QByPMj2RIhkJ6touTezXFMZMjuyUOCF5uCfy0UniJAQhES/zJwB1pfcMUvJsvKyvKHSeI+LvwLLAfcJr5HlpVoCY48eMyWTQucNeyzeOm7BXgufy1feml9EQZWZ+RA15HSO3JFyuubz6U7CyfYGwfjhh025m/UnEERBcjIR663mo3HjhlYIfUFUwPyRdOOQG5UuZSN5YQlQb4IFsbg7W1/6+q73yaB8uDSGTRbpmbcT3Q2DqtcmzAgbMCSOamzUyzLfNwkFAP6lEXWZJV5HCbIS0v/5H605uwQD3yMirLNITJNMqAP0KWYrmB9JKN5+PfGRh2YvRMxT3KPDHPwSXQdoeb4/BFN9DdqaRQ3JC7PmUCfe1GgBRzo3v3WQ2+Rjm+Vkq6uCpB7YQM/4GccpwuatBioOIhd0q2q720Qc+M9unTo9QZOE797iPxIw0weaUStSWSchQ+iOiPGvejPq6hGswxs1pGyfee8dtBi4oNsIcFEeu+f+zh8Nb+VKhQcNaVGDgVBA2LV/6NklP6F2IiwKIanGM26rercOM8bSmZEwSL+miA9PXhpIES9BrwExAdCMKAptodom8x4BlGSb2ZiFUzNzqeLmbx8Pvf9f8Fm7DMSbmIKARI+IcNVdkpFzWEu8fHW9NiIJyYHd4MAFRHTedRFiiXurxUPg5USAOIYakfGdUdvwpIlVuLkYNL2PZ/geA9hlfpeVcxXm8vHt9IUuaWpPa/NqU7K2W0PQB52gbCisYEITHX2xKJMLFM0tMpptot1dXW7XkaJbK3oY2C2CBhx14dQWhqhL4JwvV3Fybnwq3vZXy5lg/aV76Pty9Oc8SxOo8syAr1OX8c5UZxVbwlQOnLOiyYMVYSbccrJKs5a2QDnjdzq+rB7z3qdjz22V61oo8iUkC/TaEHsaiPMH3tJMMrTmHlGiD/pZZ5I/m87xkv1FZF4a6yiJ6hDaTXxfxuYsy96HA8UsYCge6SuxzbLk55+makH/Nn8y5Svzvv0n5hS9UDBGrd1ERG3vnRG7sB7CkF93TM1J3YevLJgRClSlvKoCMjjfFk+ScT+e3UCfVu3nv20SP+GgDRjLmkQQBPoGZDAm9Q3WhRRAotOcRvofhMsqih7GRgKfDfYVZrl8AKS2BBQT0EVygyqNdKQ28c0VVIQoku1oBGjcqihwhmQD/AB75wQjWxXATPlc0nCm6M89vtgDFN7A8mxUUeJSOc46Nkhwy3CE/B3wOG7/0YFUCddirYMKvgBs7ys9HdpyrtsSG0mKSSFqjApkXk9EAruq2LkiTHOnDoUMOrnft4rEgKduMNAO8/IOhHQjkC6ITtfectJlwXf6We8qH/0pWx/OiXz9RONSzq3jWtdC5ky/LmfkBzQfIAMg3OqnP1TStVHNdvqNmbvdJigCzJjeoMhZKj7tFa+4BDPEUh+3PIjmEGYY2+CulLyVnemZhMd7dOHVBYyFnjcHaV5Sodr2XtD/StpiVIAoEpvlnVN2KBbIRATZMNAPQXitmJQCHdm6hKYUk1zoxCmCqPakT5H5yK1nijVoOMRXV2O22ecfxHFV+95R1Z4b6rcQJWmjJypuzXr74Lc09axDmcllb+kgnb6vukcH+hurIR5+IdRDPXxyV5KejII7JOUCek58XE5uQx2izzFYWZOoiyF7gbxOtXcWir1H2pzMcfoefcWCTppxhzB7AXEXuUoOUppx7UTB45nqs5LNygzagbagLxdaNnTSzFZ5eSVd4WJcMn3xBEKPdp3tc2zpuV084rNqcYsrK1qyaKaKOTIN/LCobm3iwNBXUCsXCeEkZ5IMzWIi0Dzxk/FTtL34rExE0WKIJxsTAoIJ3Uw72NcbGN3O/n+kyX9oFmFiaxm3h/flyTwZ0xwynWuA3pBy1mbU9dj+7d/o2harv591FFW3eKOgeQrLIlVk+8Qk8shlBgsi6kToxorHAktTmzeVxgLud4zVTrJ0j127KbxSPzNEf9Zr09ZzM7GRldLGU4l7ggaEemi0BlN8By/wvQ3whJrf3+avTW8wKB2nfmQYljSBRexeOHyst4L+SewlPiGTdcQmdDqPlHxpAhHX9C/kjbkuJJyagvDedfQzZbd0hrIEsO81AMdAcT4FxCoYv72LAA0UjIGisHBohJpxAv2oUOm7BTqY+4wNctV9n8Zi8wWP0LZoT//7ARxXhDxWUlYNVjXSSi71o+cPJHwbzFJFMSmm/ZqpOPTGd+q4OPQUookkwH+Q59rjycDaie9aVV7l01pOM0ECDs1+lvVtGa+ltM14ArUIwAyF61ijOVx/OYjc6JVMw1RMEhF+aMErqzWwDhQAReAbWgo8t35SXGTVG8xrWREtZPUvP//DlKt945vx/eNag9DPSL0HXgXz/jc9tXK5fUgO/uT9CRGpI4ub8pWS0Z3fgC1GJuuSXqq/CvHaBZlxnFn2lCv7x0+DdjT86M4+qalBpBYtzj10D8XaBvD19yGoQqdgubINeCgZztE/WcLiGt6B1SQhYexH+seLBv2gCWJBjZTWdAeGCuN2LESZNAUVQJu2vvhifzCt+eQ2qDhwiNdbBrZ8mXd0Whx2A08xjZaqV5FfzFEjhjBXPrHBIj/FqNdcZCkSIGj5MZXDWZYPp6aYg5wE6x3e8nUKLFm1DKbgTF9SILg+3g8ZC3uj1EO5n9e87Hz081sxIIhTzb7bXBF57zDUxyNSWco8wxOAg8ANNlvzvdnria7wYeUUUJ5/ZePwJApcLFl9o+APuUWexNJQjGii6maDge0YuhLa+x38KqPsZAcnRVPbtZBBDOfkUmuRmieX4r1+MzYtN/a5fzku7Y9jWuXsuXn1c7S5hjN57Hcot6Pj7P3maGvjggMOLHQws+wjbfBOkeAMN4WgiaLxzBQcuHpLJ0n4Myu9roZ9ilYTY3x3dwHLPrgfo9g1vq8di2TzKRKHsicrDhW5qU+eFh/SH+l6Z4oPmFvN+V0/5yt0F2rjvYVCgXa3/fYSZ9RU3fIWgM169qiTfZs62oK7AmCJJ4IC01YEfsVCXowttF/6u7ciRfCBIuWaf35Q/dd2EY+1cgZ35jk01pRMdEjO4AzQSlSYG7m+RAKqFDzIGoI/9OE2uA80zbNpcRtm5EIYP3/5eFNXNeQQbFAN2B1pjqUea9s/C0NkP+k1AoYItFIqskaF+0rkWmaW2sHMl27al/f80Cr7R+Jff5ZRFMhSUa4M9so0YbmiAAuPnKXUiPZL7k6ldykCryqgFmWyDx+NYng/ee0OjeIc6Tr4xyj5tmFZ+PyovX7RREpJgdOkuOLhsVGcP0rgROVyfeX+0loQmkMQ/PQdpMjAopD3X6W8ciloJ3YRYFGEnyzOpeA9Z0yHfUQ0yf6SPkpzS5SL3JUY0LL9kxECm17IEeHLN1A01TAM15SvrfVSGKhJGUhV4aS3cUMmt9/AARjp0L7Hbuto7y08xe5agKuCLURCor9NzvJKODVwHirigHpEwryl2B2RlEGE2XGeGXf4M+CZDp8obAjcue81OqhyAODtcH5SmKCt0I72UQdUbYaVY5PUZBX6tvlEF20n9BrsJyOnZ3Di7HcBQfWfyJTuZf7APecY/aLc4KRREwDF721bLejPBsm691oWaBH+dYuN8W/40OEKSKbT9XKgNdbvzdFNFb2I3LZXd8cbpe10AbmoJUSWxivBp19troItnNNN4/jnwcCgsZULAYuavYscPOr7kWsOSZZwRQCtBP7ubJuE54jRNI/rTSaIjIX52JDJM2YyOpcj4rw0PzC3Cg+z0xw8b/6HktAfAl+6rulhNRs6wjg3e5M2W61JzEtKp/+orp1WKvVOlV7QoPi7+AY6IJaB+NbuHJGpLGmQtey61prWCwH84cP15b1TsuSYG/T4TO+Fak96vP/ReBp7yPXuuz2vREDLTQeuq89NbHV4U5TZFDULK+pptfr9WjHsjvJUS5yjajBl6qmShgNerNOHkalPAT7alBV2lCeJrqZAbXS2hD/xzspAN8pHeuFG8cLZuv8ozmVDwa0H2DHSxWaXKa/jhn6ZqdPOmSuJfA7EXSuoJoPCjwgOg95ExbAZrDZ/fEf66FUf1a2zcSul/PJjVxYS+PPHiyCjZ3vlxfTXCnzpUiz9C9GA5rwo744OYvAneUtbkSJvzKyWMx/y4b/x3AbbIZ0VzIDNy3/4MVwoJhsG4qdFihlp4hhBv8kiJ9ssEvMrCA7i84izZ/IcdLjdAlLi5Jx77c3VMfdiKMlRc1ilRei9HSt9m5T7DfrSftjEGduopDtio9Nl6RFb9b6UTpyMqiZm+EKOBGNwyhVXqtv550d7GyegBPFdih67o/lvyfbMnxXYbwFWZrqCfL+EaBN3N275t1vzUJsVnZ4g4XW7SJr76c/1kVaLE6zlMcLDSiHREW021Vx1kamDWTBVIq8IptKVgUs3g02A1mMjjZJ6BymQWQ7v5Fi7zbCKdjM1Obh6L2/lPu9yJpNqoYtRKFNqkKQcqA6bRsKr9EOA0OPQVEe73eZ4jvkOYH2mZknsEq0rOIK+uhO9mD6Y0Pm8EwJRf9Vk/ijDXR18DDMqZS828DDG5NDvonAyBBX8UcjCU/NTCYJL7cdk/4HHtXg/v0kcjqGe/le0dnHg5843MP835bzNT0++K9WUo7J27nERqciYu9zN9+4k7ETt/Lxh7XhWn7Yw+zRa5fveyX8TJo3UF1YzjMGyY46fV2Sl8E2QIQ='
+     - op: replace
+       path: /spec/encryptedData/type
+     - op: replace
+       path: /spec/template/metadata/name
+       value: 'du1-2-falcon-cars2-lab-bmc-secret'
+     - op: replace
+       path: /spec/template/metadata/namespace
+       value: 'falcon'

--- a/core/advanced-cluster-management/03-clusterimageset.yaml
+++ b/core/advanced-cluster-management/03-clusterimageset.yaml
@@ -2,6 +2,16 @@
 apiVersion: hive.openshift.io/v1
 kind: ClusterImageSet
 metadata:
+  name: openshift-4.14.0-rc.3
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "3"
+spec:
+  releaseImage: quay.io/openshift-release-dev/ocp-release:4.14.0-rc.3-x86_64
+---
+apiVersion: hive.openshift.io/v1
+kind: ClusterImageSet
+metadata:
   name: openshift-4.14.0-rc.2
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true


### PR DESCRIPTION
This PR:

1. Deploys the Bronco and Falcon clusters with OpenShift 4.14 release candidate 3.  Kernel will be 5.14.0-284.34.1.rt14.319.el9_2.x86_64.
2. Switches catalog indexes from my (Dave's) index to the 4.14 one.
3. Operator versions will be dated 28-September.
4. Bronco will use Intel non supported driver.  Falcon will use Red Hat supported driver.