### PR TITLE
Pin OpenShift GitOps operator to version 1.9

### DIFF
--- a/bootstrap/overlays/default/kustomization.yaml
+++ b/bootstrap/overlays/default/kustomization.yaml
@@ -4,7 +4,7 @@ kind: Kustomization
 
 
 resources:
-  - github.com/redhat-cop/gitops-catalog/openshift-gitops-operator/operator/overlays/latest?ref=main
+  - github.com/redhat-cop/gitops-catalog/openshift-gitops-operator/operator/overlays/gitops-1.9?ref=main
   - github.com/redhat-partner-solutions/vse-catalog/components/argocd/overlays/4.12?ref=main
   - openshift-gitops-rbac-policy.yaml
   - ../../../components/applicationsets


### PR DESCRIPTION
This PR:

1. Pins the version of the OpenShift GitOps Operator to version 1.9.  This is being used in lieu of "latest", which does not align to the ZTP solution: https://docs.openshift.com/container-platform/4.14/scalability_and_performance/ztp_far_edge/ztp-preparing-the-hub-cluster.html

Expected that this will remain true for OpenShift 4.13 and 4.14.  This may be adjusted in the future with subsequent PRs as the ZTP solution tests new versions of GitOps (ArgoCD).