### PR TITLE
11oct re-add autosync for core applicationset

### DIFF
--- a/bootstrap/overlays/default/kustomization.yaml
+++ b/bootstrap/overlays/default/kustomization.yaml
@@ -4,7 +4,7 @@ kind: Kustomization
 
 
 resources:
-  - github.com/redhat-cop/gitops-catalog/openshift-gitops-operator/operator/overlays/gitops-1.9?ref=main
+  - github.com/redhat-cop/gitops-catalog/openshift-gitops-operator/operator/overlays/gitops-1.10?ref=main
   - github.com/redhat-partner-solutions/vse-catalog/components/argocd/overlays/4.13?ref=main
   - openshift-gitops-rbac-policy.yaml
   - ../../../components/applicationsets

--- a/components/applicationsets/core-components-appset.yaml
+++ b/components/applicationsets/core-components-appset.yaml
@@ -16,7 +16,16 @@ spec:
       name: '{{path.basename}}'
     spec:
       project: default
-      syncPolicy: {}
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        retry:
+          limit: 15
+          backoff:
+            duration: 15s
+            factor: 2
+            maxDuration: 5m
       source:
         repoURL: https://github.com/redhat-partner-solutions/vse-carslab-hub
         targetRevision: cars2


### PR DESCRIPTION
This PR:

1. re-adds autosync.
2. Settles to using OpenShift GitOps 1.10, as manual reconciliation and uninstallation is not possible without disruption.