### PR TITLE
fix for sealed secrets operator gitops-cop main branch

### DIFF
--- a/core/sealed-secrets/kustomization.yaml
+++ b/core/sealed-secrets/kustomization.yaml
@@ -3,4 +3,4 @@ kind: Kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 
 resources:
-  - github.com/redhat-cop/gitops-catalog/sealed-secrets-operator/overlays/default?ref=main
+  - github.com/redhat-cop/gitops-catalog/sealed-secrets-operator/operator/overlays/default?ref=main


### PR DESCRIPTION
This PR:

1. Corrects kustomization for the sealed secrets Operator for the main branch.