### PR TITLE
20nov deploy 3 clusters and update policies for 4.14 ztp plugin

### DIFF
--- a/bootstrap/overlays/default/kustomization.yaml
+++ b/bootstrap/overlays/default/kustomization.yaml
@@ -5,7 +5,7 @@ kind: Kustomization
 
 resources:
   - github.com/redhat-cop/gitops-catalog/openshift-gitops-operator/operator/overlays/gitops-1.10?ref=main
-  - github.com/redhat-partner-solutions/vse-catalog/components/argocd/overlays/4.13?ref=main
+  - github.com/redhat-partner-solutions/vse-catalog/components/argocd/overlays/4.14?ref=main
   - openshift-gitops-rbac-policy.yaml
   - ../../../components/applicationsets
   - ../../../components/argocdproj

--- a/clusters/ztp-policies/common/common-policies/common-du-ranGen-414.yaml
+++ b/clusters/ztp-policies/common/common-policies/common-du-ranGen-414.yaml
@@ -1,0 +1,73 @@
+---
+apiVersion: ran.openshift.io/v1
+kind: PolicyGenTemplate
+metadata:
+  name: "common-du-414"
+  namespace: "ztp-common"
+spec:
+  bindingRules:
+    # These policies will correspond to all clusters with this label:
+    common-du-414: "true"
+  sourceFiles:
+    # Create operators policies that will be installed in all clusters
+    - fileName: SriovSubscription.yaml
+      policyName: "subscriptions-policy"
+      spec:
+        source: redhat-operators
+    - fileName: SriovSubscriptionNS.yaml
+      policyName: "subscriptions-policy"
+    - fileName: SriovSubscriptionOperGroup.yaml
+      policyName: "subscriptions-policy"
+    - fileName: SriovOperatorStatus.yaml
+      policyName: "subscriptions-policy"
+    - fileName: PtpSubscription.yaml
+      policyName: "subscriptions-policy"
+      spec:
+        source: redhat-operators
+    - fileName: PtpSubscriptionNS.yaml
+      policyName: "subscriptions-policy"
+    - fileName: PtpSubscriptionOperGroup.yaml
+      policyName: "subscriptions-policy"
+    - fileName: PtpOperatorStatus.yaml
+      policyName: "subscriptions-policy"
+    - fileName: ClusterLogNS.yaml
+      policyName: "subscriptions-policy"
+    - fileName: ClusterLogOperGroup.yaml
+      policyName: "subscriptions-policy"
+    - fileName: ClusterLogSubscription.yaml
+      policyName: "subscriptions-policy"
+      spec:
+        source: redhat-operators
+    - fileName: ClusterLogOperatorStatus.yaml
+      policyName: "subscriptions-policy"
+    - fileName: StorageNS.yaml
+      policyName: "subscriptions-policy"
+    - fileName: StorageOperGroup.yaml
+      policyName: "subscriptions-policy"
+    - fileName: StorageSubscription.yaml
+      policyName: "subscriptions-policy"
+      spec:
+        source: redhat-operators
+    - fileName: StorageOperatorStatus.yaml
+      policyName: "subscriptions-policy"
+    - fileName: ReduceMonitoringFootprint.yaml
+      policyName: "config-policy"
+    #
+    # These CRs are in support of installation from a disconnected registry
+    #
+#    - fileName: OperatorHub.yaml
+#      policyName: "config-policy"
+#    - fileName: DefaultCatsrc.yaml
+#      policyName: "config-policy"
+#      metadata:
+#        name: redhat-operators-disconnected
+#      spec:
+#        displayName: disconnected-redhat-operators
+#        image: registry.example.com:5000/disconnected-redhat-operators
+#    - fileName: DisconnectedICSP.yaml
+#      policyName: "config-policy"
+#      spec:
+#        repositoryDigestMirrors:
+#        - mirrors:
+#          - registry.example.com:5000
+#          source: registry.redhat.io

--- a/clusters/ztp-policies/common/group-policies/group-dellr740-vse1.yaml
+++ b/clusters/ztp-policies/common/group-policies/group-dellr740-vse1.yaml
@@ -18,8 +18,10 @@ spec:
         collection:
           type: vector
         curation:
+          type: curator
           curator:
             schedule: 30 3 * * *
+        managementState: Managed
     # The setting below overrides the default "worker" selector predefined in
     # the source-crs. The change is recommended on SNOs configured with PTP 
     # event notification for forward compatibility with possible SNO expansion.

--- a/clusters/ztp-policies/common/group-policies/group-dellr740xd-vse3.yaml
+++ b/clusters/ztp-policies/common/group-policies/group-dellr740xd-vse3.yaml
@@ -18,8 +18,10 @@ spec:
         collection:
           type: vector
         curation:
+          type: curator
           curator:
             schedule: 30 3 * * *
+        managementState: Managed
     # The setting below overrides the default "worker" selector predefined in
     # the source-crs. The change is recommended on SNOs configured with PTP
     # event notification for forward compatibility with possible SNO expansion.

--- a/clusters/ztp-policies/common/group-policies/group-dellr760-vse4.yaml
+++ b/clusters/ztp-policies/common/group-policies/group-dellr760-vse4.yaml
@@ -18,8 +18,10 @@ spec:
         collection:
           type: vector
         curation:
+          type: curator
           curator:
             schedule: 30 3 * * *
+        managementState: Managed
     # The setting below overrides the default "worker" selector predefined in
     # the source-crs. The change is recommended on SNOs configured with PTP
     # event notification for forward compatibility with possible SNO expansion.

--- a/clusters/ztp-policies/common/kustomization.yaml
+++ b/clusters/ztp-policies/common/kustomization.yaml
@@ -5,15 +5,17 @@ kind: Kustomization
 resources:
  - ns.yaml
  # This policy is used for VSE Loki logging
- - common-policies/common-vseloki.yaml
+ #- common-policies/common-vseloki.yaml
  # This policy is for common VSE 4.14 artifacts
- - common-policies/common-vseextras.yaml
+ #- common-policies/common-vseextras.yaml
 
 generators:
   # This is common to all RAN DU deployments
  - common-policies/common-du-ranGen.yaml
+  # This is common to all RAN DU deployments using 4.14 of the ZTP plugin
+ - common-policies/common-du-ranGen-414.yaml
   # This is common to all PreGA RAN DU deployments using the Partner Index
- - common-policies/common-ranGen-prega414-latest.yaml
+ #- common-policies/common-ranGen-prega414-latest.yaml
 
  # yamllint disable-line rule:line-length
  # This group policy is for all Dell R740 based deployments with SKU VSE-1:

--- a/clusters/ztp-siteconfig/bronco.cars2.lab/bronco-siteconfig.yaml
+++ b/clusters/ztp-siteconfig/bronco.cars2.lab/bronco-siteconfig.yaml
@@ -1,0 +1,161 @@
+---
+# yamllint disable rule:line-length
+# yamllint disable rule:comments-indentation
+apiVersion: ran.openshift.io/v1
+kind: SiteConfig
+metadata:
+  name: "bronco"
+  namespace: "bronco"
+spec:
+  baseDomain: "cars2.lab"
+  pullSecretRef:
+    name: "assisted-deployment-pull-secret"
+  clusterImageSetNameRef: "img4.14.2-x86-64-appsub"
+  sshPublicKey: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDd7Jj5iFCWv9IHJK9H+2O3lyPs36moAxeAUiHvzRS3uzqGxxB33BnTRBNDKsoDFSGJX0J4bd5b+XyCPdhFOfvn/xhmAcm6d8GALS+139e8d+No8h2QgZy0OVJFp844k4nmz4wew5/+X9DN40ZURYerekbVc58hw1+rTu0uM2jQ0cE2QmEf3qGKHx9UJW8t6IsMzwnrikBH30sYqn2NcBE+/c8JzlLc3PvvenlY0iQkpukI1A5E9GGMR9OS/q+w6FH85zvSgUatOV7Q5lg45QUF+V77DrfX5+niI+NK1g70pRvD8481SAdXrHPB5vK4vQEmJ4pz83IKYHVuPzRnjzYKv1jV33oReyyMqyk44Rsfkxl4i5SJ9z7q/EVmTjvurzD6ofi3Dg0+PL18eTcjuPFdCxSCUFsnr5N9CRHCxHRQpxoZTD7sYD4jDGNygawLvhxcvgKGBZzP53NRCzRFOMFmZsLPLQRaNOsgKRPAohmrn5l8+1xG5ltVauOwAFlKUxk="
+  clusters:
+    - clusterName: "bronco"
+      networkType: "OVNKubernetes"
+      cpuPartitioningMode: AllNodes
+      # installConfigOverrides is a generic way of passing install-config
+      # parameters through the siteConfig.  The 'capabilities' field configures
+      # the composable openshift feature.  In this 'capabilities' setting, we
+      # remove all but the marketplace component from the optional set of
+      # components.
+      # Notes:
+      # - NodeTuning is needed for 4.13 and later, not for 4.12 and earlier
+      installConfigOverrides: "{\"capabilities\":{\"baselineCapabilitySet\": \"None\", \"additionalEnabledCapabilities\": [ \"marketplace\", \"NodeTuning\" ] }}"
+      # It is strongly recommended to include crun manifests as part of the additional install-time manifests for 4.13+.
+      # The crun manifests can be obtained from source-crs/optional-extra-manifest/ and added to the git repo ie.sno-extra-manifest.
+      # extraManifestPath: sno-extra-manifest
+      clusterLabels:
+        common-du-414: true
+        group-dellr760-vse4: ""
+        #vseloki: true
+        #vseextras: true
+      clusterNetwork:
+        - cidr: 10.128.0.0/14
+          hostPrefix: 23
+        - cidr: fd01::/48
+          hostPrefix: 64
+      serviceNetwork:
+        - 172.30.0.0/16
+        - fd02::/112
+      machineNetwork:
+        - cidr: 192.168.38.128/26
+        - cidr: 2600:52:7:300::0/64
+      additionalNTPSources:
+        - clock.cars2.lab
+        - clock-v6.cars2.lab
+      # Optionally; This can be used to override the KlusterletAddonConfig that is created for this cluster:
+      #crTemplates:
+      #  KlusterletAddonConfig: "KlusterletAddonConfigOverride.yaml"
+      #proxy:
+        #httpProxy: http://cars2-client.infra.cars2.lab:3128
+        #httpsProxy: http://cars2-client.infra.cars2.lab:3128
+        #noProxy: ".cars2.lab,2600:52:7:300::0/64,fd02::/112,fd01::/48,2600:52:7:38::0/64,2600:52:7:300::177,2600:52:7:300::179,2600:52:7:300::180,2600:52:7:300::181"
+      nodes:
+        - hostName: "spr760-1.bronco.cars2.lab"
+          role: "master"
+          # Optionally; This can be used to configure desired BIOS setting on a host:
+          #biosConfigRef:
+          #  filePath: "example-hw.profile"
+          bmcAddress: "idrac-virtualmedia://192.168.38.208/redfish/v1/Systems/System.Embedded.1"
+          bmcCredentialsName:
+            name: "bronco-bmc-creds-secret"
+          bootMACAddress: "ec:2a:72:51:31:b8"
+          # Use UEFISecureBoot to enable secure boot
+          bootMode: "UEFI"
+          rootDeviceHints:
+            deviceName: "/dev/disk/by-path/pci-0000:c7:00.0-scsi-0:2:15:0"
+          # example of diskPartition below is used for image registry (check ImageRegistry.md for more details), but it's not limited to this use case
+#          diskPartition:
+#            - device: /dev/disk/by-id/wwn-0x11111000000asd123 # match rootDeviceHints
+#              partitions:
+#                - mount_point: /var/imageregistry
+#                  size: 102500
+#                  start: 344844
+         # allocate partitions for persist storage used by HTTP transport subscription data for PTP and BMER operators.
+         # disk id and and size needs to be adjusted to the hardware
+         # ignitionConfigOverride: '{"ignition":{"version":"3.2.0"},"storage":{"disks":[{"device":"/dev/disk/by-id/wwn-0x11111000000asd123","wipeTable":false,"partitions":[{"sizeMiB":16,"label":"httpevent1","startMiB":350000},{"sizeMiB":16,"label":"httpevent2","startMiB":350016}]}],"filesystem":[{"device":"/dev/disk/by-partlabel/httpevent1","format":"xfs","wipeFilesystem":true},{"device":"/dev/disk/by-partlabel/httpevent2","format":"xfs","wipeFilesystem":true}]}}'
+          nodeNetwork:
+            interfaces:
+              - name: eno8303
+                macAddress: "ec:2a:72:51:31:b8"
+              - name: eno8403
+                macAddress: "ec:2a:72:51:31:b9"
+              - name: eno12399
+                macAddress: "40:a6:b7:a8:79:c8"
+              - name: eno12409
+                macAddress: "40:a6:b7:a8:79:c9"
+              - name: eno12419
+                macAddress: "40:a6:b7:a8:79:ca"
+              - name: eno12429
+                macAddress: "40:a6:b7:a8:79:cb"
+              - name: ens2f0
+                macAddress: "50:7c:6f:1f:b3:98"
+              - name: ens2f1
+                macAddress: "50:7c:6f:1f:b3:99"
+              - name: ens2f2
+                macAddress: "50:7c:6f:1f:b3:9a"
+              - name: ens2f3
+                macAddress: "50:7c:6f:1f:b3:9b"
+            config:
+              interfaces:
+                - name: eno8303
+                  type: ethernet
+                  state: up
+                  ipv4:
+                    enabled: true
+                    address:
+                      - ip: "192.168.38.145"
+                        prefix-length: 26
+                    dhcp: false
+                  ipv6:
+                    enabled: true
+                    address:
+                      - ip: "2600:52:7:300::145"
+                        prefix-length: 64
+                    autoconf: false
+                    dhcp: false
+                - name: eno8403
+                  type: ethernet
+                  state: down
+                - name: eno12399
+                  type: ethernet
+                  state: up
+                - name: eno12409
+                  type: ethernet
+                  state: down
+                - name: eno12419
+                  type: ethernet
+                  state: down
+                - name: eno12429
+                  type: ethernet
+                  state: down
+                - name: ens2f0
+                  type: ethernet
+                  state: down
+                - name: ens2f1
+                  type: ethernet
+                  state: down
+                - name: ens2f2
+                  type: ethernet
+                  state: down
+                - name: ens2f3
+                  type: ethernet
+                  state: down
+              dns-resolver:
+                config:
+                  search:
+                    - cars2.lab
+                  server:
+                    - 192.168.38.12
+                    - 2600:52:7:38::12
+              routes:
+                config:
+                  - destination: 0.0.0.0/0
+                    next-hop-address: 192.168.38.129
+                    next-hop-interface: eno8303
+                  - destination: ::/0
+                    next-hop-address: 2600:52:7:300::1
+                    next-hop-interface: eno8303

--- a/clusters/ztp-siteconfig/bronco.cars2.lab/kustomization.yaml
+++ b/clusters/ztp-siteconfig/bronco.cars2.lab/kustomization.yaml
@@ -1,0 +1,47 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+generators:
+ - bronco-siteconfig.yaml
+
+resources:
+ - github.com/redhat-partner-solutions/vse-ocp-bases/base/ztp/site-config?ref=main
+
+patches:
+ - target:
+    kind: Secret
+   patch: |-
+     - op: replace
+       path: /metadata/name
+       value: 'bronco-bmc-creds-secret'
+     - op: replace
+       path: /metadata/namespace
+       value: 'bronco'
+     - op: replace
+       path: /data/username
+       value: 'cm9vdA=='
+     - op: replace
+       path: /data/password
+       value: 'UmVkSGF0VGVsY28hMjM0'
+ - target:
+    kind: SealedSecret
+   # yamllint disable rule:line-length
+   patch: |-
+     - op: replace
+       path: /metadata/name
+       value: 'assisted-deployment-pull-secret'
+     - op: replace
+       path: /metadata/namespace
+       value: 'bronco'
+     - op: replace
+       path: /spec/encryptedData/.dockerconfigjson
+       value: 'AgB6WVvkNvdFvkISS0FeZk7bvHimMl00hQz1/QcvHqerzSPvcx9XRmC8aV1/nFLz39QByPMj2RIhkJ6touTezXFMZMjuyUOCF5uCfy0UniJAQhES/zJwB1pfcMUvJsvKyvKHSeI+LvwLLAfcJr5HlpVoCY48eMyWTQucNeyzeOm7BXgufy1feml9EQZWZ+RA15HSO3JFyuubz6U7CyfYGwfjhh025m/UnEERBcjIR663mo3HjhlYIfUFUwPyRdOOQG5UuZSN5YQlQb4IFsbg7W1/6+q73yaB8uDSGTRbpmbcT3Q2DqtcmzAgbMCSOamzUyzLfNwkFAP6lEXWZJV5HCbIS0v/5H605uwQD3yMirLNITJNMqAP0KWYrmB9JKN5+PfGRh2YvRMxT3KPDHPwSXQdoeb4/BFN9DdqaRQ3JC7PmUCfe1GgBRzo3v3WQ2+Rjm+Vkq6uCpB7YQM/4GccpwuatBioOIhd0q2q720Qc+M9unTo9QZOE797iPxIw0weaUStSWSchQ+iOiPGvejPq6hGswxs1pGyfee8dtBi4oNsIcFEeu+f+zh8Nb+VKhQcNaVGDgVBA2LV/6NklP6F2IiwKIanGM26rercOM8bSmZEwSL+miA9PXhpIES9BrwExAdCMKAptodom8x4BlGSb2ZiFUzNzqeLmbx8Pvf9f8Fm7DMSbmIKARI+IcNVdkpFzWEu8fHW9NiIJyYHd4MAFRHTedRFiiXurxUPg5USAOIYakfGdUdvwpIlVuLkYNL2PZ/geA9hlfpeVcxXm8vHt9IUuaWpPa/NqU7K2W0PQB52gbCisYEITHX2xKJMLFM0tMpptot1dXW7XkaJbK3oY2C2CBhx14dQWhqhL4JwvV3Fybnwq3vZXy5lg/aV76Pty9Oc8SxOo8syAr1OX8c5UZxVbwlQOnLOiyYMVYSbccrJKs5a2QDnjdzq+rB7z3qdjz22V61oo8iUkC/TaEHsaiPMH3tJMMrTmHlGiD/pZZ5I/m87xkv1FZF4a6yiJ6hDaTXxfxuYsy96HA8UsYCge6SuxzbLk55+makH/Nn8y5Svzvv0n5hS9UDBGrd1ERG3vnRG7sB7CkF93TM1J3YevLJgRClSlvKoCMjjfFk+ScT+e3UCfVu3nv20SP+GgDRjLmkQQBPoGZDAm9Q3WhRRAotOcRvofhMsqih7GRgKfDfYVZrl8AKS2BBQT0EVygyqNdKQ28c0VVIQoku1oBGjcqihwhmQD/AB75wQjWxXATPlc0nCm6M89vtgDFN7A8mxUUeJSOc46Nkhwy3CE/B3wOG7/0YFUCddirYMKvgBs7ys9HdpyrtsSG0mKSSFqjApkXk9EAruq2LkiTHOnDoUMOrnft4rEgKduMNAO8/IOhHQjkC6ITtfectJlwXf6We8qH/0pWx/OiXz9RONSzq3jWtdC5ky/LmfkBzQfIAMg3OqnP1TStVHNdvqNmbvdJigCzJjeoMhZKj7tFa+4BDPEUh+3PIjmEGYY2+CulLyVnemZhMd7dOHVBYyFnjcHaV5Sodr2XtD/StpiVIAoEpvlnVN2KBbIRATZMNAPQXitmJQCHdm6hKYUk1zoxCmCqPakT5H5yK1nijVoOMRXV2O22ecfxHFV+95R1Z4b6rcQJWmjJypuzXr74Lc09axDmcllb+kgnb6vukcH+hurIR5+IdRDPXxyV5KejII7JOUCek58XE5uQx2izzFYWZOoiyF7gbxOtXcWir1H2pzMcfoefcWCTppxhzB7AXEXuUoOUppx7UTB45nqs5LNygzagbagLxdaNnTSzFZ5eSVd4WJcMn3xBEKPdp3tc2zpuV084rNqcYsrK1qyaKaKOTIN/LCobm3iwNBXUCsXCeEkZ5IMzWIi0Dzxk/FTtL34rExE0WKIJxsTAoIJ3Uw72NcbGN3O/n+kyX9oFmFiaxm3h/flyTwZ0xwynWuA3pBy1mbU9dj+7d/o2harv591FFW3eKOgeQrLIlVk+8Qk8shlBgsi6kToxorHAktTmzeVxgLud4zVTrJ0j127KbxSPzNEf9Zr09ZzM7GRldLGU4l7ggaEemi0BlN8By/wvQ3whJrf3+avTW8wKB2nfmQYljSBRexeOHyst4L+SewlPiGTdcQmdDqPlHxpAhHX9C/kjbkuJJyagvDedfQzZbd0hrIEsO81AMdAcT4FxCoYv72LAA0UjIGisHBohJpxAv2oUOm7BTqY+4wNctV9n8Zi8wWP0LZoT//7ARxXhDxWUlYNVjXSSi71o+cPJHwbzFJFMSmm/ZqpOPTGd+q4OPQUookkwH+Q59rjycDaie9aVV7l01pOM0ECDs1+lvVtGa+ltM14ArUIwAyF61ijOVx/OYjc6JVMw1RMEhF+aMErqzWwDhQAReAbWgo8t35SXGTVG8xrWREtZPUvP//DlKt945vx/eNag9DPSL0HXgXz/jc9tXK5fUgO/uT9CRGpI4ub8pWS0Z3fgC1GJuuSXqq/CvHaBZlxnFn2lCv7x0+DdjT86M4+qalBpBYtzj10D8XaBvD19yGoQqdgubINeCgZztE/WcLiGt6B1SQhYexH+seLBv2gCWJBjZTWdAeGCuN2LESZNAUVQJu2vvhifzCt+eQ2qDhwiNdbBrZ8mXd0Whx2A08xjZaqV5FfzFEjhjBXPrHBIj/FqNdcZCkSIGj5MZXDWZYPp6aYg5wE6x3e8nUKLFm1DKbgTF9SILg+3g8ZC3uj1EO5n9e87Hz081sxIIhTzb7bXBF57zDUxyNSWco8wxOAg8ANNlvzvdnria7wYeUUUJ5/ZePwJApcLFl9o+APuUWexNJQjGii6maDge0YuhLa+x38KqPsZAcnRVPbtZBBDOfkUmuRmieX4r1+MzYtN/a5fzku7Y9jWuXsuXn1c7S5hjN57Hcot6Pj7P3maGvjggMOLHQws+wjbfBOkeAMN4WgiaLxzBQcuHpLJ0n4Myu9roZ9ilYTY3x3dwHLPrgfo9g1vq8di2TzKRKHsicrDhW5qU+eFh/SH+l6Z4oPmFvN+V0/5yt0F2rjvYVCgXa3/fYSZ9RU3fIWgM169qiTfZs62oK7AmCJJ4IC01YEfsVCXowttF/6u7ciRfCBIuWaf35Q/dd2EY+1cgZ35jk01pRMdEjO4AzQSlSYG7m+RAKqFDzIGoI/9OE2uA80zbNpcRtm5EIYP3/5eFNXNeQQbFAN2B1pjqUea9s/C0NkP+k1AoYItFIqskaF+0rkWmaW2sHMl27al/f80Cr7R+Jff5ZRFMhSUa4M9so0YbmiAAuPnKXUiPZL7k6ldykCryqgFmWyDx+NYng/ee0OjeIc6Tr4xyj5tmFZ+PyovX7RREpJgdOkuOLhsVGcP0rgROVyfeX+0loQmkMQ/PQdpMjAopD3X6W8ciloJ3YRYFGEnyzOpeA9Z0yHfUQ0yf6SPkpzS5SL3JUY0LL9kxECm17IEeHLN1A01TAM15SvrfVSGKhJGUhV4aS3cUMmt9/AARjp0L7Hbuto7y08xe5agKuCLURCor9NzvJKODVwHirigHpEwryl2B2RlEGE2XGeGXf4M+CZDp8obAjcue81OqhyAODtcH5SmKCt0I72UQdUbYaVY5PUZBX6tvlEF20n9BrsJyOnZ3Di7HcBQfWfyJTuZf7APecY/aLc4KRREwDF721bLejPBsm691oWaBH+dYuN8W/40OEKSKbT9XKgNdbvzdFNFb2I3LZXd8cbpe10AbmoJUSWxivBp19troItnNNN4/jnwcCgsZULAYuavYscPOr7kWsOSZZwRQCtBP7ubJuE54jRNI/rTSaIjIX52JDJM2YyOpcj4rw0PzC3Cg+z0xw8b/6HktAfAl+6rulhNRs6wjg3e5M2W61JzEtKp/+orp1WKvVOlV7QoPi7+AY6IJaB+NbuHJGpLGmQtey61prWCwH84cP15b1TsuSYG/T4TO+Fak96vP/ReBp7yPXuuz2vREDLTQeuq89NbHV4U5TZFDULK+pptfr9WjHsjvJUS5yjajBl6qmShgNerNOHkalPAT7alBV2lCeJrqZAbXS2hD/xzspAN8pHeuFG8cLZuv8ozmVDwa0H2DHSxWaXKa/jhn6ZqdPOmSuJfA7EXSuoJoPCjwgOg95ExbAZrDZ/fEf66FUf1a2zcSul/PJjVxYS+PPHiyCjZ3vlxfTXCnzpUiz9C9GA5rwo744OYvAneUtbkSJvzKyWMx/y4b/x3AbbIZ0VzIDNy3/4MVwoJhsG4qdFihlp4hhBv8kiJ9ssEvMrCA7i84izZ/IcdLjdAlLi5Jx77c3VMfdiKMlRc1ilRei9HSt9m5T7DfrSftjEGduopDtio9Nl6RFb9b6UTpyMqiZm+EKOBGNwyhVXqtv550d7GyegBPFdih67o/lvyfbMnxXYbwFWZrqCfL+EaBN3N275t1vzUJsVnZ4g4XW7SJr76c/1kVaLE6zlMcLDSiHREW021Vx1kamDWTBVIq8IptKVgUs3g02A1mMjjZJ6BymQWQ7v5Fi7zbCKdjM1Obh6L2/lPu9yJpNqoYtRKFNqkKQcqA6bRsKr9EOA0OPQVEe73eZ4jvkOYH2mZknsEq0rOIK+uhO9mD6Y0Pm8EwJRf9Vk/ijDXR18DDMqZS828DDG5NDvonAyBBX8UcjCU/NTCYJL7cdk/4HHtXg/v0kcjqGe/le0dnHg5843MP835bzNT0++K9WUo7J27nERqciYu9zN9+4k7ETt/Lxh7XhWn7Yw+zRa5fveyX8TJo3UF1YzjMGyY46fV2Sl8E2QIQ='
+     - op: replace
+       path: /spec/encryptedData/type
+     - op: replace
+       path: /spec/template/metadata/name
+       value: 'bronco-bmc-creds-secret'
+     - op: replace
+       path: /spec/template/metadata/namespace
+       value: 'bronco'

--- a/clusters/ztp-siteconfig/cormorant.wpc.test/cormorant-siteconfig.yaml
+++ b/clusters/ztp-siteconfig/cormorant.wpc.test/cormorant-siteconfig.yaml
@@ -1,0 +1,115 @@
+---
+# yamllint disable rule:line-length
+# yamllint disable rule:comments-indentation
+apiVersion: ran.openshift.io/v1
+kind: SiteConfig
+metadata:
+  name: "cormorant"
+  namespace: "cormorant"
+spec:
+  baseDomain: "wpc.test"
+  pullSecretRef:
+    name: "assisted-deployment-pull-secret"
+  clusterImageSetNameRef: "img4.14.2-x86-64-appsub"
+  sshPublicKey: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDd7Jj5iFCWv9IHJK9H+2O3lyPs36moAxeAUiHvzRS3uzqGxxB33BnTRBNDKsoDFSGJX0J4bd5b+XyCPdhFOfvn/xhmAcm6d8GALS+139e8d+No8h2QgZy0OVJFp844k4nmz4wew5/+X9DN40ZURYerekbVc58hw1+rTu0uM2jQ0cE2QmEf3qGKHx9UJW8t6IsMzwnrikBH30sYqn2NcBE+/c8JzlLc3PvvenlY0iQkpukI1A5E9GGMR9OS/q+w6FH85zvSgUatOV7Q5lg45QUF+V77DrfX5+niI+NK1g70pRvD8481SAdXrHPB5vK4vQEmJ4pz83IKYHVuPzRnjzYKv1jV33oReyyMqyk44Rsfkxl4i5SJ9z7q/EVmTjvurzD6ofi3Dg0+PL18eTcjuPFdCxSCUFsnr5N9CRHCxHRQpxoZTD7sYD4jDGNygawLvhxcvgKGBZzP53NRCzRFOMFmZsLPLQRaNOsgKRPAohmrn5l8+1xG5ltVauOwAFlKUxk="
+  clusters:
+    - clusterName: "cormorant"
+      networkType: "OVNKubernetes"
+      cpuPartitioningMode: AllNodes
+      # installConfigOverrides is a generic way of passing install-config
+      # parameters through the siteConfig.  The 'capabilities' field configures
+      # the composable openshift feature.  In this 'capabilities' setting, we
+      # remove all but the marketplace component from the optional set of
+      # components.
+      # Notes:
+      # - NodeTuning is needed for 4.13 and later, not for 4.12 and earlier
+      installConfigOverrides: "{\"capabilities\":{\"baselineCapabilitySet\": \"None\", \"additionalEnabledCapabilities\": [ \"marketplace\", \"NodeTuning\" ] }}"
+      # It is strongly recommended to include crun manifests as part of the additional install-time manifests for 4.13+.
+      # The crun manifests can be obtained from source-crs/optional-extra-manifest/ and added to the git repo ie.sno-extra-manifest.
+      # extraManifestPath: sno-extra-manifest
+      clusterLabels:
+        common-du-414: true
+        group-dellr740xd-vse3: ""
+        #sites: "cormorant-wpc-test"
+        #vseloki: true
+        #vseextras: true
+      clusterNetwork:
+        - cidr: 10.128.0.0/14
+          hostPrefix: 23
+#        - cidr: fd01::/48
+#          hostPrefix: 64
+      serviceNetwork:
+        - 172.30.0.0/16
+#        - fd02::/112
+      machineNetwork:
+        - cidr: 192.168.49.128/25
+#        - cidr: fd00:6:6:2051::0/64
+      additionalNTPSources:
+        - clock.cars2.lab
+#        - clock-v6.cars2.lab
+      #crTemplates:
+      #  KlusterletAddonConfig: "KlusterletAddonConfigOverride.yaml"
+      nodes:
+        - hostName: "r740-u27.cormorant.wpc.test"
+          role: master
+          # Optionally; This can be used to configure desired BIOS setting on a host:
+          #biosConfigRef:
+          #  filePath: "example-hw.profile"
+          bmcAddress: "idrac-virtualmedia://192.168.49.241/redfish/v1/Systems/System.Embedded.1"
+          bmcCredentialsName:
+            name: "cormorant-bmc-creds-secret"
+          bootMACAddress: "40:a6:b7:2b:29:10"
+          bootMode: "UEFI"
+          rootDeviceHints:
+            deviceName: "/dev/disk/by-path/pci-0000:d8:00.0-scsi-0:2:0:0"
+          # example of diskPartition below is used for image registry (check ImageRegistry.md for more details), but it's not limited to this use case
+#          diskPartition:
+#            - device: /dev/disk/by-id/wwn-0x11111000000asd123 # match rootDeviceHints
+#              partitions:
+#                - mount_point: /var/imageregistry
+#                  size: 102500
+#                  start: 344844
+         # allocate partitions for persist storage used by HTTP transport subscription data for PTP and BMER operators.
+         # disk id and and size needs to be adjusted to the hardware
+         # ignitionConfigOverride: '{"ignition":{"version":"3.2.0"},"storage":{"disks":[{"device":"/dev/disk/by-id/wwn-0x11111000000asd123","wipeTable":false,"partitions":[{"sizeMiB":16,"label":"httpevent1","startMiB":350000},{"sizeMiB":16,"label":"httpevent2","startMiB":350016}]}],"filesystem":[{"device":"/dev/disk/by-partlabel/httpevent1","format":"xfs","wipeFilesystem":true},{"device":"/dev/disk/by-partlabel/httpevent2","format":"xfs","wipeFilesystem":true}]}}'
+          nodeNetwork:
+            interfaces:
+              - name: ens3f0
+                macAddress: "40:a6:b7:2b:29:10"
+              - name: ens3f1
+                macAddress: "40:a6:b7:2b:29:11"
+            config:
+              interfaces:
+                - name: ens3f1
+                  type: ethernet
+                  state: down
+                - name: ens3f0
+                  type: ethernet
+                  state: up
+                  ipv4:
+                    enabled: true
+                    address:
+                      - ip: 192.168.49.141
+                        prefix-length: 25
+                  ipv6:
+                    enabled: false
+#                    address:
+#                      - ip: fd00:6:6:2051::60
+#                        prefix-length: 64
+#                    autoconf: false
+#                    dhcp: false
+              dns-resolver:
+                config:
+                  search:
+                    - wpc.test
+                  server:
+                    - 192.168.38.12
+#                    - 2600:52:7:38::12
+              routes:
+                config:
+                  - destination: 0.0.0.0/0
+                    next-hop-address: 192.168.49.129
+                    next-hop-interface: ens3f0
+#                  - destination: ::/0
+#                    next-hop-address: fd00:6:6:2051::1
+#                    next-hop-interface: ens3f1

--- a/clusters/ztp-siteconfig/cormorant.wpc.test/kustomization.yaml
+++ b/clusters/ztp-siteconfig/cormorant.wpc.test/kustomization.yaml
@@ -1,0 +1,47 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+generators:
+ - cormorant-siteconfig.yaml
+
+resources:
+ - github.com/redhat-partner-solutions/vse-ocp-bases/base/ztp/site-config?ref=main
+
+patches:
+ - target:
+    kind: Secret
+   patch: |-
+     - op: replace
+       path: /metadata/name
+       value: 'cormorant-bmc-creds-secret'
+     - op: replace
+       path: /metadata/namespace
+       value: 'cormorant'
+     - op: replace
+       path: /data/username
+       value: 'cm9vdA=='
+     - op: replace
+       path: /data/password
+       value: 'Y2FsdmluCg=='
+ - target:
+    kind: SealedSecret
+   # yamllint disable rule:line-length
+   patch: |-
+     - op: replace
+       path: /metadata/name
+       value: 'assisted-deployment-pull-secret'
+     - op: replace
+       path: /metadata/namespace
+       value: 'cormorant'
+     - op: replace
+       path: /spec/encryptedData/.dockerconfigjson
+       value: 'AgB6WVvkNvdFvkISS0FeZk7bvHimMl00hQz1/QcvHqerzSPvcx9XRmC8aV1/nFLz39QByPMj2RIhkJ6touTezXFMZMjuyUOCF5uCfy0UniJAQhES/zJwB1pfcMUvJsvKyvKHSeI+LvwLLAfcJr5HlpVoCY48eMyWTQucNeyzeOm7BXgufy1feml9EQZWZ+RA15HSO3JFyuubz6U7CyfYGwfjhh025m/UnEERBcjIR663mo3HjhlYIfUFUwPyRdOOQG5UuZSN5YQlQb4IFsbg7W1/6+q73yaB8uDSGTRbpmbcT3Q2DqtcmzAgbMCSOamzUyzLfNwkFAP6lEXWZJV5HCbIS0v/5H605uwQD3yMirLNITJNMqAP0KWYrmB9JKN5+PfGRh2YvRMxT3KPDHPwSXQdoeb4/BFN9DdqaRQ3JC7PmUCfe1GgBRzo3v3WQ2+Rjm+Vkq6uCpB7YQM/4GccpwuatBioOIhd0q2q720Qc+M9unTo9QZOE797iPxIw0weaUStSWSchQ+iOiPGvejPq6hGswxs1pGyfee8dtBi4oNsIcFEeu+f+zh8Nb+VKhQcNaVGDgVBA2LV/6NklP6F2IiwKIanGM26rercOM8bSmZEwSL+miA9PXhpIES9BrwExAdCMKAptodom8x4BlGSb2ZiFUzNzqeLmbx8Pvf9f8Fm7DMSbmIKARI+IcNVdkpFzWEu8fHW9NiIJyYHd4MAFRHTedRFiiXurxUPg5USAOIYakfGdUdvwpIlVuLkYNL2PZ/geA9hlfpeVcxXm8vHt9IUuaWpPa/NqU7K2W0PQB52gbCisYEITHX2xKJMLFM0tMpptot1dXW7XkaJbK3oY2C2CBhx14dQWhqhL4JwvV3Fybnwq3vZXy5lg/aV76Pty9Oc8SxOo8syAr1OX8c5UZxVbwlQOnLOiyYMVYSbccrJKs5a2QDnjdzq+rB7z3qdjz22V61oo8iUkC/TaEHsaiPMH3tJMMrTmHlGiD/pZZ5I/m87xkv1FZF4a6yiJ6hDaTXxfxuYsy96HA8UsYCge6SuxzbLk55+makH/Nn8y5Svzvv0n5hS9UDBGrd1ERG3vnRG7sB7CkF93TM1J3YevLJgRClSlvKoCMjjfFk+ScT+e3UCfVu3nv20SP+GgDRjLmkQQBPoGZDAm9Q3WhRRAotOcRvofhMsqih7GRgKfDfYVZrl8AKS2BBQT0EVygyqNdKQ28c0VVIQoku1oBGjcqihwhmQD/AB75wQjWxXATPlc0nCm6M89vtgDFN7A8mxUUeJSOc46Nkhwy3CE/B3wOG7/0YFUCddirYMKvgBs7ys9HdpyrtsSG0mKSSFqjApkXk9EAruq2LkiTHOnDoUMOrnft4rEgKduMNAO8/IOhHQjkC6ITtfectJlwXf6We8qH/0pWx/OiXz9RONSzq3jWtdC5ky/LmfkBzQfIAMg3OqnP1TStVHNdvqNmbvdJigCzJjeoMhZKj7tFa+4BDPEUh+3PIjmEGYY2+CulLyVnemZhMd7dOHVBYyFnjcHaV5Sodr2XtD/StpiVIAoEpvlnVN2KBbIRATZMNAPQXitmJQCHdm6hKYUk1zoxCmCqPakT5H5yK1nijVoOMRXV2O22ecfxHFV+95R1Z4b6rcQJWmjJypuzXr74Lc09axDmcllb+kgnb6vukcH+hurIR5+IdRDPXxyV5KejII7JOUCek58XE5uQx2izzFYWZOoiyF7gbxOtXcWir1H2pzMcfoefcWCTppxhzB7AXEXuUoOUppx7UTB45nqs5LNygzagbagLxdaNnTSzFZ5eSVd4WJcMn3xBEKPdp3tc2zpuV084rNqcYsrK1qyaKaKOTIN/LCobm3iwNBXUCsXCeEkZ5IMzWIi0Dzxk/FTtL34rExE0WKIJxsTAoIJ3Uw72NcbGN3O/n+kyX9oFmFiaxm3h/flyTwZ0xwynWuA3pBy1mbU9dj+7d/o2harv591FFW3eKOgeQrLIlVk+8Qk8shlBgsi6kToxorHAktTmzeVxgLud4zVTrJ0j127KbxSPzNEf9Zr09ZzM7GRldLGU4l7ggaEemi0BlN8By/wvQ3whJrf3+avTW8wKB2nfmQYljSBRexeOHyst4L+SewlPiGTdcQmdDqPlHxpAhHX9C/kjbkuJJyagvDedfQzZbd0hrIEsO81AMdAcT4FxCoYv72LAA0UjIGisHBohJpxAv2oUOm7BTqY+4wNctV9n8Zi8wWP0LZoT//7ARxXhDxWUlYNVjXSSi71o+cPJHwbzFJFMSmm/ZqpOPTGd+q4OPQUookkwH+Q59rjycDaie9aVV7l01pOM0ECDs1+lvVtGa+ltM14ArUIwAyF61ijOVx/OYjc6JVMw1RMEhF+aMErqzWwDhQAReAbWgo8t35SXGTVG8xrWREtZPUvP//DlKt945vx/eNag9DPSL0HXgXz/jc9tXK5fUgO/uT9CRGpI4ub8pWS0Z3fgC1GJuuSXqq/CvHaBZlxnFn2lCv7x0+DdjT86M4+qalBpBYtzj10D8XaBvD19yGoQqdgubINeCgZztE/WcLiGt6B1SQhYexH+seLBv2gCWJBjZTWdAeGCuN2LESZNAUVQJu2vvhifzCt+eQ2qDhwiNdbBrZ8mXd0Whx2A08xjZaqV5FfzFEjhjBXPrHBIj/FqNdcZCkSIGj5MZXDWZYPp6aYg5wE6x3e8nUKLFm1DKbgTF9SILg+3g8ZC3uj1EO5n9e87Hz081sxIIhTzb7bXBF57zDUxyNSWco8wxOAg8ANNlvzvdnria7wYeUUUJ5/ZePwJApcLFl9o+APuUWexNJQjGii6maDge0YuhLa+x38KqPsZAcnRVPbtZBBDOfkUmuRmieX4r1+MzYtN/a5fzku7Y9jWuXsuXn1c7S5hjN57Hcot6Pj7P3maGvjggMOLHQws+wjbfBOkeAMN4WgiaLxzBQcuHpLJ0n4Myu9roZ9ilYTY3x3dwHLPrgfo9g1vq8di2TzKRKHsicrDhW5qU+eFh/SH+l6Z4oPmFvN+V0/5yt0F2rjvYVCgXa3/fYSZ9RU3fIWgM169qiTfZs62oK7AmCJJ4IC01YEfsVCXowttF/6u7ciRfCBIuWaf35Q/dd2EY+1cgZ35jk01pRMdEjO4AzQSlSYG7m+RAKqFDzIGoI/9OE2uA80zbNpcRtm5EIYP3/5eFNXNeQQbFAN2B1pjqUea9s/C0NkP+k1AoYItFIqskaF+0rkWmaW2sHMl27al/f80Cr7R+Jff5ZRFMhSUa4M9so0YbmiAAuPnKXUiPZL7k6ldykCryqgFmWyDx+NYng/ee0OjeIc6Tr4xyj5tmFZ+PyovX7RREpJgdOkuOLhsVGcP0rgROVyfeX+0loQmkMQ/PQdpMjAopD3X6W8ciloJ3YRYFGEnyzOpeA9Z0yHfUQ0yf6SPkpzS5SL3JUY0LL9kxECm17IEeHLN1A01TAM15SvrfVSGKhJGUhV4aS3cUMmt9/AARjp0L7Hbuto7y08xe5agKuCLURCor9NzvJKODVwHirigHpEwryl2B2RlEGE2XGeGXf4M+CZDp8obAjcue81OqhyAODtcH5SmKCt0I72UQdUbYaVY5PUZBX6tvlEF20n9BrsJyOnZ3Di7HcBQfWfyJTuZf7APecY/aLc4KRREwDF721bLejPBsm691oWaBH+dYuN8W/40OEKSKbT9XKgNdbvzdFNFb2I3LZXd8cbpe10AbmoJUSWxivBp19troItnNNN4/jnwcCgsZULAYuavYscPOr7kWsOSZZwRQCtBP7ubJuE54jRNI/rTSaIjIX52JDJM2YyOpcj4rw0PzC3Cg+z0xw8b/6HktAfAl+6rulhNRs6wjg3e5M2W61JzEtKp/+orp1WKvVOlV7QoPi7+AY6IJaB+NbuHJGpLGmQtey61prWCwH84cP15b1TsuSYG/T4TO+Fak96vP/ReBp7yPXuuz2vREDLTQeuq89NbHV4U5TZFDULK+pptfr9WjHsjvJUS5yjajBl6qmShgNerNOHkalPAT7alBV2lCeJrqZAbXS2hD/xzspAN8pHeuFG8cLZuv8ozmVDwa0H2DHSxWaXKa/jhn6ZqdPOmSuJfA7EXSuoJoPCjwgOg95ExbAZrDZ/fEf66FUf1a2zcSul/PJjVxYS+PPHiyCjZ3vlxfTXCnzpUiz9C9GA5rwo744OYvAneUtbkSJvzKyWMx/y4b/x3AbbIZ0VzIDNy3/4MVwoJhsG4qdFihlp4hhBv8kiJ9ssEvMrCA7i84izZ/IcdLjdAlLi5Jx77c3VMfdiKMlRc1ilRei9HSt9m5T7DfrSftjEGduopDtio9Nl6RFb9b6UTpyMqiZm+EKOBGNwyhVXqtv550d7GyegBPFdih67o/lvyfbMnxXYbwFWZrqCfL+EaBN3N275t1vzUJsVnZ4g4XW7SJr76c/1kVaLE6zlMcLDSiHREW021Vx1kamDWTBVIq8IptKVgUs3g02A1mMjjZJ6BymQWQ7v5Fi7zbCKdjM1Obh6L2/lPu9yJpNqoYtRKFNqkKQcqA6bRsKr9EOA0OPQVEe73eZ4jvkOYH2mZknsEq0rOIK+uhO9mD6Y0Pm8EwJRf9Vk/ijDXR18DDMqZS828DDG5NDvonAyBBX8UcjCU/NTCYJL7cdk/4HHtXg/v0kcjqGe/le0dnHg5843MP835bzNT0++K9WUo7J27nERqciYu9zN9+4k7ETt/Lxh7XhWn7Yw+zRa5fveyX8TJo3UF1YzjMGyY46fV2Sl8E2QIQ='
+     - op: replace
+       path: /spec/encryptedData/type
+     - op: replace
+       path: /spec/template/metadata/name
+       value: 'cormorant-bmc-creds-secret'
+     - op: replace
+       path: /spec/template/metadata/namespace
+       value: 'cormorant'

--- a/clusters/ztp-siteconfig/puffin.wpc.test/kustomization.yaml
+++ b/clusters/ztp-siteconfig/puffin.wpc.test/kustomization.yaml
@@ -1,0 +1,47 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+generators:
+ - puffin-siteconfig.yaml
+
+resources:
+ - github.com/redhat-partner-solutions/vse-ocp-bases/base/ztp/site-config?ref=main
+
+patches:
+ - target:
+    kind: Secret
+   patch: |-
+     - op: replace
+       path: /metadata/name
+       value: 'puffin-bmc-creds-secret'
+     - op: replace
+       path: /metadata/namespace
+       value: 'puffin'
+     - op: replace
+       path: /data/username
+       value: 'cm9vdA=='
+     - op: replace
+       path: /data/password
+       value: 'Y2FsdmluCg=='
+ - target:
+    kind: SealedSecret
+   # yamllint disable rule:line-length
+   patch: |-
+     - op: replace
+       path: /metadata/name
+       value: 'assisted-deployment-pull-secret'
+     - op: replace
+       path: /metadata/namespace
+       value: 'puffin'
+     - op: replace
+       path: /spec/encryptedData/.dockerconfigjson
+       value: 'AgB6WVvkNvdFvkISS0FeZk7bvHimMl00hQz1/QcvHqerzSPvcx9XRmC8aV1/nFLz39QByPMj2RIhkJ6touTezXFMZMjuyUOCF5uCfy0UniJAQhES/zJwB1pfcMUvJsvKyvKHSeI+LvwLLAfcJr5HlpVoCY48eMyWTQucNeyzeOm7BXgufy1feml9EQZWZ+RA15HSO3JFyuubz6U7CyfYGwfjhh025m/UnEERBcjIR663mo3HjhlYIfUFUwPyRdOOQG5UuZSN5YQlQb4IFsbg7W1/6+q73yaB8uDSGTRbpmbcT3Q2DqtcmzAgbMCSOamzUyzLfNwkFAP6lEXWZJV5HCbIS0v/5H605uwQD3yMirLNITJNMqAP0KWYrmB9JKN5+PfGRh2YvRMxT3KPDHPwSXQdoeb4/BFN9DdqaRQ3JC7PmUCfe1GgBRzo3v3WQ2+Rjm+Vkq6uCpB7YQM/4GccpwuatBioOIhd0q2q720Qc+M9unTo9QZOE797iPxIw0weaUStSWSchQ+iOiPGvejPq6hGswxs1pGyfee8dtBi4oNsIcFEeu+f+zh8Nb+VKhQcNaVGDgVBA2LV/6NklP6F2IiwKIanGM26rercOM8bSmZEwSL+miA9PXhpIES9BrwExAdCMKAptodom8x4BlGSb2ZiFUzNzqeLmbx8Pvf9f8Fm7DMSbmIKARI+IcNVdkpFzWEu8fHW9NiIJyYHd4MAFRHTedRFiiXurxUPg5USAOIYakfGdUdvwpIlVuLkYNL2PZ/geA9hlfpeVcxXm8vHt9IUuaWpPa/NqU7K2W0PQB52gbCisYEITHX2xKJMLFM0tMpptot1dXW7XkaJbK3oY2C2CBhx14dQWhqhL4JwvV3Fybnwq3vZXy5lg/aV76Pty9Oc8SxOo8syAr1OX8c5UZxVbwlQOnLOiyYMVYSbccrJKs5a2QDnjdzq+rB7z3qdjz22V61oo8iUkC/TaEHsaiPMH3tJMMrTmHlGiD/pZZ5I/m87xkv1FZF4a6yiJ6hDaTXxfxuYsy96HA8UsYCge6SuxzbLk55+makH/Nn8y5Svzvv0n5hS9UDBGrd1ERG3vnRG7sB7CkF93TM1J3YevLJgRClSlvKoCMjjfFk+ScT+e3UCfVu3nv20SP+GgDRjLmkQQBPoGZDAm9Q3WhRRAotOcRvofhMsqih7GRgKfDfYVZrl8AKS2BBQT0EVygyqNdKQ28c0VVIQoku1oBGjcqihwhmQD/AB75wQjWxXATPlc0nCm6M89vtgDFN7A8mxUUeJSOc46Nkhwy3CE/B3wOG7/0YFUCddirYMKvgBs7ys9HdpyrtsSG0mKSSFqjApkXk9EAruq2LkiTHOnDoUMOrnft4rEgKduMNAO8/IOhHQjkC6ITtfectJlwXf6We8qH/0pWx/OiXz9RONSzq3jWtdC5ky/LmfkBzQfIAMg3OqnP1TStVHNdvqNmbvdJigCzJjeoMhZKj7tFa+4BDPEUh+3PIjmEGYY2+CulLyVnemZhMd7dOHVBYyFnjcHaV5Sodr2XtD/StpiVIAoEpvlnVN2KBbIRATZMNAPQXitmJQCHdm6hKYUk1zoxCmCqPakT5H5yK1nijVoOMRXV2O22ecfxHFV+95R1Z4b6rcQJWmjJypuzXr74Lc09axDmcllb+kgnb6vukcH+hurIR5+IdRDPXxyV5KejII7JOUCek58XE5uQx2izzFYWZOoiyF7gbxOtXcWir1H2pzMcfoefcWCTppxhzB7AXEXuUoOUppx7UTB45nqs5LNygzagbagLxdaNnTSzFZ5eSVd4WJcMn3xBEKPdp3tc2zpuV084rNqcYsrK1qyaKaKOTIN/LCobm3iwNBXUCsXCeEkZ5IMzWIi0Dzxk/FTtL34rExE0WKIJxsTAoIJ3Uw72NcbGN3O/n+kyX9oFmFiaxm3h/flyTwZ0xwynWuA3pBy1mbU9dj+7d/o2harv591FFW3eKOgeQrLIlVk+8Qk8shlBgsi6kToxorHAktTmzeVxgLud4zVTrJ0j127KbxSPzNEf9Zr09ZzM7GRldLGU4l7ggaEemi0BlN8By/wvQ3whJrf3+avTW8wKB2nfmQYljSBRexeOHyst4L+SewlPiGTdcQmdDqPlHxpAhHX9C/kjbkuJJyagvDedfQzZbd0hrIEsO81AMdAcT4FxCoYv72LAA0UjIGisHBohJpxAv2oUOm7BTqY+4wNctV9n8Zi8wWP0LZoT//7ARxXhDxWUlYNVjXSSi71o+cPJHwbzFJFMSmm/ZqpOPTGd+q4OPQUookkwH+Q59rjycDaie9aVV7l01pOM0ECDs1+lvVtGa+ltM14ArUIwAyF61ijOVx/OYjc6JVMw1RMEhF+aMErqzWwDhQAReAbWgo8t35SXGTVG8xrWREtZPUvP//DlKt945vx/eNag9DPSL0HXgXz/jc9tXK5fUgO/uT9CRGpI4ub8pWS0Z3fgC1GJuuSXqq/CvHaBZlxnFn2lCv7x0+DdjT86M4+qalBpBYtzj10D8XaBvD19yGoQqdgubINeCgZztE/WcLiGt6B1SQhYexH+seLBv2gCWJBjZTWdAeGCuN2LESZNAUVQJu2vvhifzCt+eQ2qDhwiNdbBrZ8mXd0Whx2A08xjZaqV5FfzFEjhjBXPrHBIj/FqNdcZCkSIGj5MZXDWZYPp6aYg5wE6x3e8nUKLFm1DKbgTF9SILg+3g8ZC3uj1EO5n9e87Hz081sxIIhTzb7bXBF57zDUxyNSWco8wxOAg8ANNlvzvdnria7wYeUUUJ5/ZePwJApcLFl9o+APuUWexNJQjGii6maDge0YuhLa+x38KqPsZAcnRVPbtZBBDOfkUmuRmieX4r1+MzYtN/a5fzku7Y9jWuXsuXn1c7S5hjN57Hcot6Pj7P3maGvjggMOLHQws+wjbfBOkeAMN4WgiaLxzBQcuHpLJ0n4Myu9roZ9ilYTY3x3dwHLPrgfo9g1vq8di2TzKRKHsicrDhW5qU+eFh/SH+l6Z4oPmFvN+V0/5yt0F2rjvYVCgXa3/fYSZ9RU3fIWgM169qiTfZs62oK7AmCJJ4IC01YEfsVCXowttF/6u7ciRfCBIuWaf35Q/dd2EY+1cgZ35jk01pRMdEjO4AzQSlSYG7m+RAKqFDzIGoI/9OE2uA80zbNpcRtm5EIYP3/5eFNXNeQQbFAN2B1pjqUea9s/C0NkP+k1AoYItFIqskaF+0rkWmaW2sHMl27al/f80Cr7R+Jff5ZRFMhSUa4M9so0YbmiAAuPnKXUiPZL7k6ldykCryqgFmWyDx+NYng/ee0OjeIc6Tr4xyj5tmFZ+PyovX7RREpJgdOkuOLhsVGcP0rgROVyfeX+0loQmkMQ/PQdpMjAopD3X6W8ciloJ3YRYFGEnyzOpeA9Z0yHfUQ0yf6SPkpzS5SL3JUY0LL9kxECm17IEeHLN1A01TAM15SvrfVSGKhJGUhV4aS3cUMmt9/AARjp0L7Hbuto7y08xe5agKuCLURCor9NzvJKODVwHirigHpEwryl2B2RlEGE2XGeGXf4M+CZDp8obAjcue81OqhyAODtcH5SmKCt0I72UQdUbYaVY5PUZBX6tvlEF20n9BrsJyOnZ3Di7HcBQfWfyJTuZf7APecY/aLc4KRREwDF721bLejPBsm691oWaBH+dYuN8W/40OEKSKbT9XKgNdbvzdFNFb2I3LZXd8cbpe10AbmoJUSWxivBp19troItnNNN4/jnwcCgsZULAYuavYscPOr7kWsOSZZwRQCtBP7ubJuE54jRNI/rTSaIjIX52JDJM2YyOpcj4rw0PzC3Cg+z0xw8b/6HktAfAl+6rulhNRs6wjg3e5M2W61JzEtKp/+orp1WKvVOlV7QoPi7+AY6IJaB+NbuHJGpLGmQtey61prWCwH84cP15b1TsuSYG/T4TO+Fak96vP/ReBp7yPXuuz2vREDLTQeuq89NbHV4U5TZFDULK+pptfr9WjHsjvJUS5yjajBl6qmShgNerNOHkalPAT7alBV2lCeJrqZAbXS2hD/xzspAN8pHeuFG8cLZuv8ozmVDwa0H2DHSxWaXKa/jhn6ZqdPOmSuJfA7EXSuoJoPCjwgOg95ExbAZrDZ/fEf66FUf1a2zcSul/PJjVxYS+PPHiyCjZ3vlxfTXCnzpUiz9C9GA5rwo744OYvAneUtbkSJvzKyWMx/y4b/x3AbbIZ0VzIDNy3/4MVwoJhsG4qdFihlp4hhBv8kiJ9ssEvMrCA7i84izZ/IcdLjdAlLi5Jx77c3VMfdiKMlRc1ilRei9HSt9m5T7DfrSftjEGduopDtio9Nl6RFb9b6UTpyMqiZm+EKOBGNwyhVXqtv550d7GyegBPFdih67o/lvyfbMnxXYbwFWZrqCfL+EaBN3N275t1vzUJsVnZ4g4XW7SJr76c/1kVaLE6zlMcLDSiHREW021Vx1kamDWTBVIq8IptKVgUs3g02A1mMjjZJ6BymQWQ7v5Fi7zbCKdjM1Obh6L2/lPu9yJpNqoYtRKFNqkKQcqA6bRsKr9EOA0OPQVEe73eZ4jvkOYH2mZknsEq0rOIK+uhO9mD6Y0Pm8EwJRf9Vk/ijDXR18DDMqZS828DDG5NDvonAyBBX8UcjCU/NTCYJL7cdk/4HHtXg/v0kcjqGe/le0dnHg5843MP835bzNT0++K9WUo7J27nERqciYu9zN9+4k7ETt/Lxh7XhWn7Yw+zRa5fveyX8TJo3UF1YzjMGyY46fV2Sl8E2QIQ='
+     - op: replace
+       path: /spec/encryptedData/type
+     - op: replace
+       path: /spec/template/metadata/name
+       value: 'puffin-bmc-creds-secret'
+     - op: replace
+       path: /spec/template/metadata/namespace
+       value: 'puffin'

--- a/clusters/ztp-siteconfig/puffin.wpc.test/puffin-siteconfig.yaml
+++ b/clusters/ztp-siteconfig/puffin.wpc.test/puffin-siteconfig.yaml
@@ -1,0 +1,120 @@
+---
+# yamllint disable rule:line-length
+# yamllint disable rule:comments-indentation
+apiVersion: ran.openshift.io/v1
+kind: SiteConfig
+metadata:
+  name: "puffin"
+  namespace: "puffin"
+spec:
+  baseDomain: "wpc.test"
+  pullSecretRef:
+    name: "assisted-deployment-pull-secret"
+  clusterImageSetNameRef: "img4.14.2-x86-64-appsub"
+  sshPublicKey: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDd7Jj5iFCWv9IHJK9H+2O3lyPs36moAxeAUiHvzRS3uzqGxxB33BnTRBNDKsoDFSGJX0J4bd5b+XyCPdhFOfvn/xhmAcm6d8GALS+139e8d+No8h2QgZy0OVJFp844k4nmz4wew5/+X9DN40ZURYerekbVc58hw1+rTu0uM2jQ0cE2QmEf3qGKHx9UJW8t6IsMzwnrikBH30sYqn2NcBE+/c8JzlLc3PvvenlY0iQkpukI1A5E9GGMR9OS/q+w6FH85zvSgUatOV7Q5lg45QUF+V77DrfX5+niI+NK1g70pRvD8481SAdXrHPB5vK4vQEmJ4pz83IKYHVuPzRnjzYKv1jV33oReyyMqyk44Rsfkxl4i5SJ9z7q/EVmTjvurzD6ofi3Dg0+PL18eTcjuPFdCxSCUFsnr5N9CRHCxHRQpxoZTD7sYD4jDGNygawLvhxcvgKGBZzP53NRCzRFOMFmZsLPLQRaNOsgKRPAohmrn5l8+1xG5ltVauOwAFlKUxk="
+  clusters:
+    - clusterName: "puffin"
+      networkType: "OVNKubernetes"
+      cpuPartitioningMode: AllNodes
+      # installConfigOverrides is a generic way of passing install-config
+      # parameters through the siteConfig.  The 'capabilities' field configures
+      # the composable openshift feature.  In this 'capabilities' setting, we
+      # remove all but the marketplace component from the optional set of
+      # components.
+      # Notes:
+      # - NodeTuning is needed for 4.13 and later, not for 4.12 and earlier
+      installConfigOverrides: "{\"capabilities\":{\"baselineCapabilitySet\": \"None\", \"additionalEnabledCapabilities\": [ \"marketplace\", \"NodeTuning\" ] }}"
+      # It is strongly recommended to include crun manifests as part of the additional install-time manifests for 4.13+.
+      # The crun manifests can be obtained from source-crs/optional-extra-manifest/ and added to the git repo ie.sno-extra-manifest.
+      # extraManifestPath: sno-extra-manifest
+      clusterLabels:
+        common-du-414: true
+        group-dellr740-vse1: ""
+        #sites: "puffin-wpc-test"
+        #vseloki: true
+        #vseextras: true
+      clusterNetwork:
+        - cidr: 10.128.0.0/14
+          hostPrefix: 23
+#        - cidr: fd01::/48
+#          hostPrefix: 64
+      serviceNetwork:
+        - 172.30.0.0/16
+#        - fd02::/112
+      machineNetwork:
+        - cidr: 192.168.49.128/25
+#        - cidr: fd00:6:6:2051::0/64
+      additionalNTPSources:
+        - clock.cars2.lab
+#        - clock-v6.cars2.lab
+      #crTemplates:
+      #  KlusterletAddonConfig: "KlusterletAddonConfigOverride.yaml"
+      nodes:
+        - hostName: "r740-u3.puffin.wpc.test"
+          role: master
+          # Optionally; This can be used to configure desired BIOS setting on a host:
+          #biosConfigRef:
+          #  filePath: "example-hw.profile"
+          bmcAddress: "idrac-virtualmedia://192.168.49.251/redfish/v1/Systems/System.Embedded.1"
+          bmcCredentialsName:
+            name: "puffin-bmc-creds-secret"
+          bootMACAddress: "40:a6:b7:2b:2b:31"
+          bootMode: "UEFI"
+          rootDeviceHints:
+            wwn: "0x62cea7f06271f8002720a81f298bfdcc"
+          # example of diskPartition below is used for image registry (check ImageRegistry.md for more details), but it's not limited to this use case
+#          diskPartition:
+#            - device: /dev/disk/by-id/wwn-0x11111000000asd123 # match rootDeviceHints
+#              partitions:
+#                - mount_point: /var/imageregistry
+#                  size: 102500
+#                  start: 344844
+         # allocate partitions for persist storage used by HTTP transport subscription data for PTP and BMER operators.
+         # disk id and and size needs to be adjusted to the hardware
+         # ignitionConfigOverride: '{"ignition":{"version":"3.2.0"},"storage":{"disks":[{"device":"/dev/disk/by-id/wwn-0x11111000000asd123","wipeTable":false,"partitions":[{"sizeMiB":16,"label":"httpevent1","startMiB":350000},{"sizeMiB":16,"label":"httpevent2","startMiB":350016}]}],"filesystem":[{"device":"/dev/disk/by-partlabel/httpevent1","format":"xfs","wipeFilesystem":true},{"device":"/dev/disk/by-partlabel/httpevent2","format":"xfs","wipeFilesystem":true}]}}'
+          nodeNetwork:
+            interfaces:
+              - name: ens2f0
+                macAddress: "50:7c:6f:1f:b5:4c"
+              - name: ens2f3
+                macAddress: "50:7c:6f:1f:b5:4f"
+              - name: ens3f1
+                macAddress: "40:a6:b7:2b:2b:31"
+            config:
+              interfaces:
+                - name: ens2f0
+                  type: ethernet
+                  state: down
+                - name: ens2f3
+                  type: ethernet
+                  state: down
+                - name: ens3f1
+                  type: ethernet
+                  state: up
+                  ipv4:
+                    enabled: true
+                    address:
+                      - ip: 192.168.49.151
+                        prefix-length: 25
+                  ipv6:
+                    enabled: false
+#                    address:
+#                      - ip: fd00:6:6:2051::60
+#                        prefix-length: 64
+#                    autoconf: false
+#                    dhcp: false
+              dns-resolver:
+                config:
+                  search:
+                    - wpc.test
+                  server:
+                    - 192.168.38.12
+#                    - 2600:52:7:38::12
+              routes:
+                config:
+                  - destination: 0.0.0.0/0
+                    next-hop-address: 192.168.49.129
+                    next-hop-interface: ens3f1
+#                  - destination: ::/0
+#                    next-hop-address: fd00:6:6:2051::1
+#                    next-hop-interface: ens3f1


### PR DESCRIPTION
This PR:

1. seeds an additional common policy (common-du-414) which incorporates changes in version 4.14 of the ZTP plugin where disconnected manifests are preferred, and the active default is to use these.  We are overriding this to return to connected behavior.
2. adjusts group policy to accommodate a workaround for https://issues.redhat.com/browse/OCPBUGS-23295.
3. adjusts the ZTP plugin to use version 4.14 from the VSE catalog: https://github.com/redhat-partner-solutions/vse-catalog/pull/44.
4. deploys clusters cormorant, puffin, and bronco.