### PR TITLE
Dec 18 - vse3 policy updates

### DIFF
--- a/clusters/ztp-policies/common/group-policies/group-dellr740xd-vse3.yaml
+++ b/clusters/ztp-policies/common/group-policies/group-dellr740xd-vse3.yaml
@@ -45,6 +45,67 @@ spec:
         profile:
         - name: "grandmaster"
           phc2sysOpts: -r -u 0 -m -O -37 -N 8 -R 16 -s ens7f0 -n 24
+          plugins:
+            e810:
+              enableDefaultConfig: true
+              settings:
+                LocalMaxHoldoverOffSet: 1500
+                LocalHoldoverTimeout: 14400
+                MaxInSpecOffset: 100
+            ublxCmds:
+              - args: #ubxtool -P 29.20 -z CFG-HW-ANT_CFG_VOLTCTRL,1
+                - "-P"
+                - "29.20"
+                - "-z"
+                - "CFG-HW-ANT_CFG_VOLTCTRL,1"
+                reportOutput: false
+              - args: #ubxtool -P 29.20 -e GPS
+                  - "-P"
+                  - "29.20"
+                  - "-e"
+                  - "GPS"
+                reportOutput: false
+              - args: #ubxtool -P 29.20 -d Galileo
+                  - "-P"
+                  - "29.20"
+                  - "-d"
+                  - "Galileo"
+                reportOutput: false
+              - args: #ubxtool -P 29.20 -d GLONASS
+                  - "-P"
+                  - "29.20"
+                  - "-d"
+                  - "GLONASS"
+                reportOutput: false
+              - args: #ubxtool -P 29.20 -d BeiDou
+                  - "-P"
+                  - "29.20"
+                  - "-d"
+                  - "BeiDou"
+                reportOutput: false
+              - args: #ubxtool -P 29.20 -d SBAS
+                  - "-P"
+                  - "29.20"
+                  - "-d"
+                  - "SBAS"
+                reportOutput: false
+              - args: #ubxtool -P 29.20 -t -w 5 -v 1 -e SURVEYIN,600,50000
+                  - "-P"
+                  - "29.20"
+                  - "-t"
+                  - "-w"
+                  - "5"
+                  - "-v"
+                  - "1"
+                  - "-e"
+                  - "SURVEYIN,600,50000"
+                reportOutput: true
+              - args: #ubxtool -P 29.20 -p MON-HW
+                  - "-P"
+                  - "29.20"
+                  - "-p"
+                  - "MON-HW"
+                reportOutput: true
           ptp4lConf: |
             [ens7f0]
             masterOnly 1


### PR DESCRIPTION
This PR updates PtpConfig DU policy with specific:

- Initial ublox default commands to set GNSS receiver
- Holdover settings according WPC specs (holdover can last up to 14400sec for ±1.5 µs deviation per second) 
- Class A limit Threshold --> 100ns