### PR TITLE
workload partitioning: bevo1, bevo2

### DIFF
--- a/clusters/ztp-policies/common/group-policies/group-dellr750-vse6.yaml
+++ b/clusters/ztp-policies/common/group-policies/group-dellr750-vse6.yaml
@@ -82,8 +82,8 @@ spec:
       spec:
         cpu:
           # These must be tailored for the specific hardware platform
-          isolated: "1,3,63,65,67-127"
-          reserved: "0,2,64,66"
+          isolated: "24-31,88-95,33-62,97-126"
+          reserved: "0-23,64-87,32,63,96,127"
         hugepages:
           defaultHugepagesSize: 1G
           pages:

--- a/clusters/ztp-siteconfig/bevo1.cars2.lab/bevo1-siteconfig.yaml
+++ b/clusters/ztp-siteconfig/bevo1.cars2.lab/bevo1-siteconfig.yaml
@@ -55,7 +55,7 @@ spec:
           bootMode: "UEFI"
           rootDeviceHints:
             deviceName: "/dev/disk/by-path/pci-0000:65:00.0-scsi-0:2:0:0"
-          cpuset: "0,2,64,66"
+          cpuset: "0,1,64,65"
           nodeNetwork:
             interfaces:
               - name: eno12399np0


### PR DESCRIPTION
This PR matches cpu setting in bevo1 and bevo2. Settings for bevo:

- cpuset: 0,1,64,65 --> 4 cores for control plane pods in bevo1

- Performance profile later:

```
cpu:
  balanceIsolated: false 
  isolated: 24-31,88-95,33-62,97-126
  reserved: 0-23,64-87,32,63,96,127
```

